### PR TITLE
add basic custom theme for chakra-ui

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,1 @@
+export { wrapRootElement } from './wrap-root-element';

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { wrapRootElement } from './wrap-root-element';

--- a/package.json
+++ b/package.json
@@ -23,19 +23,21 @@
     "gatsby-plugin-react-helmet": "^3.3.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-helmet": "^6.0.0"
+    "react-helmet": "^6.0.0",
+    "typeface-arvo": "^1.1.3",
+    "typeface-inter": "^3.12.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.1.0",
     "babel-jest": "^26.0.1",
     "babel-preset-gatsby": "^0.4.8",
+    "husky": "^4.2.5",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.0.1",
-    "react-test-renderer": "^16.13.1",
-    "husky": "^4.2.5",
     "lint-staged": "^10.2.8",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "react-test-renderer": "^16.13.1"
   },
   "husky": {
     "hooks": {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,9 @@ export default () => {
         About
       </Link>
       <Flex align="center" justify="center">
-        <Heading>Home</Heading>
+        <Heading size="2xl" fontFamily="Arvo">
+          Home
+        </Heading>
       </Flex>
     </Layout>
   );

--- a/wrap-root-element.js
+++ b/wrap-root-element.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ThemeProvider, theme } from '@chakra-ui/core';
+import 'typeface-inter';
+import 'typeface-arvo';
+
+const customeTheme = {
+  ...theme,
+  fonts: {
+    ...theme.fonts,
+    'heading-slab': 'Inter',
+    heading: 'Arvo',
+  },
+  fontSizes: {
+    ...theme.fontSizes,
+    helper: '0.75',
+    base: '1rem',
+    paragraph: '1rem',
+    button: '1rem',
+    lg: '1.25rem',
+    xl: '1.5rem',
+    '2xl': '2rem',
+    '3xl': '2.5rem',
+  },
+  colors: {
+    ...theme.colors,
+    'rbb-black': '#140303',
+    'rbb-gray': '#259f6c',
+    'rbb-white': '#1e6b7f',
+    'rbb-red': '#fafcd6',
+    'rbb-orange': '#f46036',
+  },
+};
+
+export const wrapRootElement = ({ element }) => (
+  <ThemeProvider theme={customeTheme}>{element}</ThemeProvider>
+);


### PR DESCRIPTION
# Describe your PR
This PR adds the beginning of a custom theme for chakra-ui. I pulled colors, typefaces, and sizes from Figma designs. I also added dependencies for the custom fonts.

I created a `wrapRootElement` component that is used in new `gatsby-ssr.js` and `gatsby-browser.js` files to ensure proper styling at build and run time.

Related to #
Fixes #

## Pages/Interfaces that will change
No pages changed

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1.

### Additional notes
