### PR TITLE
feat: adds lang attr to Helmet component.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ export default () => {
     <Layout>
       <Helmet>
         <title>Home</title>
+        <html lang="en" />
       </Helmet>
       <Flex align="center" justify="center">
         <Heading size="2xl" fontFamily="Arvo">


### PR DESCRIPTION
# Describe your PR

This change adds an `en` lang attribute to the `Helmet` component in the `index.js` page. Currently we have zero violations now after running aXe. It was the only violation I saw at the moment.
