### PR TITLE
Add Google Tagmanager and Facebook Tracking Pixel

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -100,6 +100,16 @@ module.exports = {
         isUsingColorMode: false,
       },
     },
+    {
+      resolve: 'gatsby-plugin-google-tagmanager',
+      options: {
+        id: process.env.GOOGLE_TAGMANAGER_ID, // pulls in from your .env file
+
+        // Include GTM in development.
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
+      },
+    },
     'gatsby-plugin-react-helmet',
   ],
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -110,6 +110,12 @@ module.exports = {
         includeInDevelopment: false,
       },
     },
+    {
+      resolve: `gatsby-plugin-facebook-pixel`,
+      options: {
+        pixelId: process.env.FACEBOOK_PIXEL_ID,
+      },
+    },
     'gatsby-plugin-react-helmet',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10177,6 +10177,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-chakra-ui/-/gatsby-plugin-chakra-ui-0.1.4.tgz",
       "integrity": "sha512-RofWX5ytqB7UDGQfTflXmeHOgqLXvZj4TnDE8JZyHNWiYR0vJGxM/UXBdGzC/fBwcfZWG3FUUAONk0znlUY/OQ=="
     },
+    "gatsby-plugin-facebook-pixel": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-facebook-pixel/-/gatsby-plugin-facebook-pixel-1.0.3.tgz",
+      "integrity": "sha512-IM4e+5FkpLUCV/69tU+GFXVAs0EJXBfM/BARO/6SaMqalLfj1fj4ZXUyC8kHy3RiTMuw+y8g2mdkBMZqj7RyWQ=="
+    },
     "gatsby-plugin-google-tagmanager": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10177,6 +10177,14 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-chakra-ui/-/gatsby-plugin-chakra-ui-0.1.4.tgz",
       "integrity": "sha512-RofWX5ytqB7UDGQfTflXmeHOgqLXvZj4TnDE8JZyHNWiYR0vJGxM/UXBdGzC/fBwcfZWG3FUUAONk0znlUY/OQ=="
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.4.tgz",
+      "integrity": "sha512-81WLvTQUOJSAlXZZ8Aqz5Cw36w0y2BsHJjWc5VKC83W8NMXoE6nx1SY/iOKNjWWLoW43QlVlsYU/CFqEPbMySA==",
+      "requires": {
+        "@babel/runtime": "^7.10.2"
+      }
+    },
     "gatsby-plugin-netlify": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify/-/gatsby-plugin-netlify-2.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "emotion-theming": "^10.0.27",
     "gatsby": "^2.22.20",
     "gatsby-plugin-chakra-ui": "^0.1.4",
+    "gatsby-plugin-facebook-pixel": "^1.0.3",
     "gatsby-plugin-google-tagmanager": "^2.3.4",
     "gatsby-plugin-netlify": "^2.3.4",
     "gatsby-plugin-react-helmet": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "emotion-theming": "^10.0.27",
     "gatsby": "^2.22.20",
     "gatsby-plugin-chakra-ui": "^0.1.4",
+    "gatsby-plugin-google-tagmanager": "^2.3.4",
     "gatsby-plugin-netlify": "^2.3.4",
     "gatsby-plugin-react-helmet": "^3.3.3",
     "gatsby-source-airtable": "^2.1.1",


### PR DESCRIPTION
# Describe your PR
This work is based on discussion on [this trello card](https://trello.com/c/AZccLvQH/13-add-analytics-google).
This PR includes plugins for Google Tag Manager (which can be used to dynamically insert Google Analytics tracking) and Facebook's tracking pixel.  

Fixes (trello card)

## Pages/Interfaces that will change
Google / Facebook tracking

### Screenshots / video of changes
n/a


## Steps to test

1. set up a GTM property, and set the `GOOGLE_TAGMANAGER_ID ` environment variable
1. set up a facebook tracking pixel, and set the `FACEBOOK_PIXEL_ID` environment variable
1. build and serve this branch locally, or test it out on netlify (with the envs set) - these analytics services will not run with `gatsby develop`
1. Check both services to make sure Facebook and Google see your traffic

### Additional notes
