### PR TITLE
add basic schema markup to businesses

### DIFF
--- a/src/components/Feeds/BusinessInNeedFeed.js
+++ b/src/components/Feeds/BusinessInNeedFeed.js
@@ -3,28 +3,45 @@ import { StaticQuery, graphql } from 'gatsby';
 
 import { Box } from '@chakra-ui/core';
 
-const SupportingOrgs = data => {
-  return <Box as="pre">{JSON.stringify(data, null, 2)}</Box>;
+const Businesses = data => {
+  return (
+    <Box as="ul">
+      {data.allAirtableBizInNeed.edges.map(({ node: { data } }) => (
+        <Box as="li" itemScope itemType={`http://schema.org/${data.Category}`}>
+          {/* the category in Airtable isn't going to match the schema category, will need to be fixed */}
+          <h2 itemprop="name">{data.Name}</h2>
+          <h4 itemprop="address">{data.Location}</h4>
+          {/* it would be good to get more address details as well */}
+          <span itemprop="email">{data.Email}</span>
+          <a href={data.Donation_Website}>Donate</a>
+        </Box>
+      ))}
+    </Box>
+  );
 };
 
 export default props => (
   <StaticQuery
     query={graphql`
-      query {
-        allAirtableBizInNeed {
-          nodes {
-            data {
-              Category
-              CreatedAt
-              Donation_Website
-              Email
-              Impacted_Business_Name
-              Name
+      query AllApprovedBizInNeed {
+        allAirtableBizInNeed(filter: { data: { Approved: { eq: true } } }) {
+          edges {
+            node {
+              data {
+                Approved
+                Category
+                Donation_Website
+                Email
+                Impacted_Business_Name
+                Location
+                Name
+                Other_Applicable_Links
+              }
             }
           }
         }
       }
     `}
-    render={data => <SupportingOrgs data={data} {...props} />}
+    render={data => <Businesses data={data} {...props} />}
   />
 );


### PR DESCRIPTION
# Describe your PR
This adds the very beginning of schema markup to businesses so that they can be easily parsed by scrapers like Google.

There isn't a lot of data to go on so implemented what I can. One thing to call out is that the category in Airtable isn't going to match the category types from Schema.org. Once we know all the types we'll need a map. This is a good start though! 

Related to #
Fixes #

## Pages/Interfaces that will change

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1.

### Additional notes
