### PR TITLE
add additional aria-labels to PrimaryNav

### DIFF
--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -56,7 +56,7 @@ const PrimaryNav = forwardRef(
         <Box display={['block', 'block', 'none']} mr={{ sm: '5' }}>
           <button
             onClick={handleToggle}
-            aria-expanded={isVisible}
+            aria-expanded={isVisible && !isMedium}
             aria-controls="navigation"
           >
             <VisuallyHidden>

--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -54,7 +54,11 @@ const PrimaryNav = forwardRef(
         </Flex>
 
         <Box display={['block', 'block', 'none']} mr={{ sm: '5' }}>
-          <button onClick={handleToggle}>
+          <button
+            onClick={handleToggle}
+            aria-expanded={isVisible}
+            aria-controls="navigation"
+          >
             <VisuallyHidden>
               {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
             </VisuallyHidden>
@@ -66,6 +70,7 @@ const PrimaryNav = forwardRef(
               fill={theme.colors['rbb-white']}
             >
               <title>Menu</title>
+
               <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
             </svg>
           </button>
@@ -78,6 +83,8 @@ const PrimaryNav = forwardRef(
           justify="flex-end"
           flexGrow={1}
           hidden={!isVisible || undefined}
+          aria-hidden={isVisible}
+          id="navigation"
         >
           {menuLinks.map((link, index, src) => (
             <NavItem

--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -83,7 +83,7 @@ const PrimaryNav = forwardRef(
           justify="flex-end"
           flexGrow={1}
           hidden={!isVisible || undefined}
-          aria-hidden={isVisible}
+          aria-hidden={isVisible && !isMedium}
           id="navigation"
         >
           {menuLinks.map((link, index, src) => (


### PR DESCRIPTION
# Describe your PR
- aria-controls  added to the <button> within the <Box> component wrapping the Hamburger menu. Points to the ID of the navigation.

- aria-expanded added to the <button> within the <Box> and toggled when the button is clicked.

- aria-hidden applied to the <NavMenu> component. On desktop set to false, but on mobile this should be toggled when the hamburger nav is clicked.

Related to # https://github.com/Rebuild-Black-Business/RBB-Website/issues/57
Fixes # https://github.com/Rebuild-Black-Business/RBB-Website/issues/57

## Pages/Interfaces that will change
all pages (/*) but in particular the nav

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

<img width="815" alt="Screen Shot 2020-06-07 at 7 40 40 PM" src="https://user-images.githubusercontent.com/6998954/83982769-35ba1f00-a8f7-11ea-9bf0-00251d752166.png">
<img width="555" alt="Screen Shot 2020-06-07 at 7 40 56 PM" src="https://user-images.githubusercontent.com/6998954/83982771-3652b580-a8f7-11ea-9679-63baf6199663.png">
<img width="561" alt="Screen Shot 2020-06-07 at 7 41 02 PM" src="https://user-images.githubusercontent.com/6998954/83982772-36eb4c00-a8f7-11ea-9ae6-dbf6c50f86ed.png">


## Steps to test

1. Inspect the nav element in dev tools on small and large screens and view how the DOM changes. On small screens where the hamburger menu icon appears it should also be tested by toggling the menu items.

### Additional notes
