### PR TITLE
Social Icons now scale on hover and focus

### DIFF
--- a/src/components/SVG/index.js
+++ b/src/components/SVG/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Link, useTheme, PseudoBox } from '@chakra-ui/core';
+import { Flex, Link, useTheme } from '@chakra-ui/core';
 
 /**
  * Icon container with external link

--- a/src/components/SVG/index.js
+++ b/src/components/SVG/index.js
@@ -8,20 +8,23 @@ import { Flex, Link, useTheme, PseudoBox } from '@chakra-ui/core';
 export const IconContainer = ({ children, link }) => {
   const theme = useTheme();
   return (
-    <Flex
-      as={Link}
+    <Link
       href={link}
-      isExternal
-      h={['50px', '40px']}
-      w={['50px', '40px']}
-      justify="center"
-      align="center"
       borderRadius="50%"
-      p="2"
       backgroundColor={theme.footer.iconsBackground}
+      _hover={{ transform: 'scale(1.1)' }}
+      _focus={{ transform: 'scale(1.1)' }}
+      isExternal
     >
-      <PseudoBox _hover={{ transform: 'scale(1.1)' }} />
-      {children}
-    </Flex>
+      <Flex
+        justify="center"
+        align="center"
+        p="2"
+        h={['50px', '40px']}
+        w={['50px', '40px']}
+      >
+        {children}
+      </Flex>
+    </Link>
   );
 };


### PR DESCRIPTION
# Describe your PR
Restructure HTML for proper scaling on hover and focus for social icons

Fixes hover and focus state for social icons

## Pages/Interfaces that will change

Social Links in the footer

### Screenshots / video of changes

Before
![image](https://user-images.githubusercontent.com/20157895/84105015-ad15ae80-a9dc-11ea-9184-306820225af5.png)

After
![image](https://user-images.githubusercontent.com/20157895/84104981-9a02de80-a9dc-11ea-8fdd-172422930db6.png)


## Steps to test

1. Hover over social icon in footer
2. -> See icon scale