### PR TITLE
Fix/Upgrade graphql-playground-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,12 +1385,12 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@graphql-tools/code-file-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-6.0.8.tgz",
-      "integrity": "sha512-SsSZluxk6jMa3zPjLWzo+umbTFyyTNNapp0rwiFJsWwb4J+1EUAd3NBlhjxjzP2YfZaD9ijuFRU5H0HthfRKCA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-6.0.9.tgz",
+      "integrity": "sha512-hYWns2FjemfNDwv/mLs650zrL6Kh1RLdcNFWSMT4/A/+3WgsW2CcOJL+2PB3+GBy8FwMbJO9P3nBz3bKRkhJaw==",
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/graphql-tag-pluck": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "fs-extra": "9.0.1",
         "tslib": "~2.0.0"
       },
@@ -1428,12 +1428,12 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-6.0.8.tgz",
-      "integrity": "sha512-XhvH30RpGLjft3cYhB99XJK8kDSaYwpXOiIp51mQzRber6ws/4gNsOQlcpMfmIz+y5WBciKLnzJa8IV3kA3J2A==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-6.0.9.tgz",
+      "integrity": "sha512-v3qiQspXCr0/UGu0V8nEBS1Qwkb/zscgD321PgxgYFDljvBsAuysz7Q0DXl9OYkPqwS2RTPeYZZqsgahEpfpeg==",
       "requires": {
-        "@graphql-tools/schema": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/schema": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1445,22 +1445,22 @@
       }
     },
     "@graphql-tools/git-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-6.0.8.tgz",
-      "integrity": "sha512-CAYKbKb/gr5xaEbElI7Mg5iu761CfE8F3ewslH5P+P5pmhCSkFjtJ506ztGowPJ00zP44qZy2c+L0W58KolpWQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-6.0.9.tgz",
+      "integrity": "sha512-PhVWMVuFAWsi2NSBQDgykmLknN0lhysHi0SZBz+1z6RfJnHNGXhwG05T+7Mv77+kJ2Om4q3H6uBdKiqzAbLcrQ==",
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
-        "simple-git": "2.5.0"
+        "@graphql-tools/graphql-tag-pluck": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
+        "simple-git": "2.6.0"
       }
     },
     "@graphql-tools/github-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-6.0.8.tgz",
-      "integrity": "sha512-NHH3/d+2V8eecm4XLAgqKr39qTPzA5CL1l5lACwmECapHLT3/cpHiy29IZmKjEZkZz8dovuHgNcB9AU27zyFag==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-6.0.9.tgz",
+      "integrity": "sha512-2NC50j2gFV14k5Y0dOaviwWv+y+Ce0p3of6dDUp4fY3ebAZAFcvLnsvCQqRzAfWvZAwORWXRMtPlKq/t5N7mAA==",
       "requires": {
-        "@graphql-tools/graphql-tag-pluck": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/graphql-tag-pluck": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "cross-fetch": "3.0.4"
       },
       "dependencies": {
@@ -1486,12 +1486,12 @@
       }
     },
     "@graphql-tools/graphql-file-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.0.8.tgz",
-      "integrity": "sha512-3rvp662U9oPfFMmcSSQ1yKFlLS4ZZqDjVqkSjX/oW1BeFUYQAOOgB0UYmQ1Hcj0HrHMDEUDvjLuj1FT3egQr3g==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.0.9.tgz",
+      "integrity": "sha512-Z+YIypr2SGcUwzhph3AZOnR2Mkb6Mg/Tk9neGAyYx/zvEHJMdUk21Q64B89mwBC1tPdgeEPHf4pDTVRLDk5wUg==",
       "requires": {
-        "@graphql-tools/import": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/import": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "fs-extra": "9.0.1",
         "tslib": "~2.0.0"
       },
@@ -1529,21 +1529,21 @@
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.0.8.tgz",
-      "integrity": "sha512-rqFGWsvQfgnzmWu7/k7or9HgATOx3YKE7te/VO7TaOZP7K+U372Dc1eKHXu3yBzfp1HeDjQK1OYHXhD4Gcq6kQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.0.9.tgz",
+      "integrity": "sha512-LvhIJ/pGXUAznB2WtcUNKhhkZHRD7ITZGsqOCFWoa/9c+MK7kt+sYj6D0Ve1rWOYGHnd5NyocHAnhYoIzipWng==",
       "requires": {
         "@babel/parser": "7.10.2",
         "@babel/traverse": "7.10.1",
         "@babel/types": "7.10.2",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "vue-template-compiler": "^2.6.11"
       }
     },
     "@graphql-tools/import": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.0.8.tgz",
-      "integrity": "sha512-miJytXyRy8oSJLCln/p5G8GpCDkeco4bHtMUO+d5i2WzxtOkbKnQzTRoZ3P1Hy6EmLLyVwY+6/TEAS6DYxUJfA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.0.9.tgz",
+      "integrity": "sha512-e/t5sa29PCOnOdLaoPVWHV7fxag4HX/E1V4cWqvKHs01zei8jsG76SCN6w1PJ9IouJ7YZYhN295DQihCSpuSlQ==",
       "requires": {
         "fs-extra": "9.0.1",
         "resolve-from": "5.0.0"
@@ -1582,11 +1582,11 @@
       }
     },
     "@graphql-tools/json-file-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-6.0.8.tgz",
-      "integrity": "sha512-nWMT9yWAQ0JoayA92em+az3Hdn21g6hx4YgXeoxi0O0wVxBJZ2Gds/5YnCzViAFgwBn3sP5EzEUuSkZiD2uZpA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-6.0.9.tgz",
+      "integrity": "sha512-M1/nymxnf980aKNQ2ZX8aEUb80eq/H4QrcUA4/h2iSDf3A+f52ai8FTgqmbxbosD5ApWvyVpRpeODSd9oryRXg==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "fs-extra": "9.0.1",
         "tslib": "~2.0.0"
       },
@@ -1624,11 +1624,11 @@
       }
     },
     "@graphql-tools/links": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/links/-/links-6.0.8.tgz",
-      "integrity": "sha512-Sqkvozo46cmQ18W9cq8B9VRmNVsNunlkZzb8hWKD22hqyDncEuqRsap2G+TnwXfUPxLWKwiGfpovomaa2pNBFQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/links/-/links-6.0.9.tgz",
+      "integrity": "sha512-bw++CJ7Txr49ISPHEvnw4UUE+a/2lxsGFrF99ioXJUqeiluukdjVdszgxOr+SOrW/BdJYwMh7094dRkXc07mfg==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "apollo-link": "1.2.14",
         "apollo-upload-client": "13.0.0",
         "cross-fetch": "3.0.4",
@@ -1663,16 +1663,16 @@
       }
     },
     "@graphql-tools/load": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-6.0.8.tgz",
-      "integrity": "sha512-4qNLsNiH34zXAk5VkLvrowkGa2gYESuCqxPTSnQaL/cwtZcoGOZ3E7OjZQj+2I/+qtLHOZxplVy3zTnBElkJZA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-6.0.9.tgz",
+      "integrity": "sha512-JDlLbkLlxjFF/of+HF3c+UnoK2AEgqeVS5xH6re60Khp2DiBvWOivACvPx4VxF49NLnvu1BYsGxxH0BGPbAA3A==",
       "requires": {
-        "@graphql-tools/merge": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/merge": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "globby": "11.0.1",
         "import-from": "3.0.0",
         "is-glob": "4.0.1",
-        "p-limit": "2.3.0",
+        "p-limit": "3.0.1",
         "tslib": "~2.0.0",
         "unixify": "1.0.0",
         "valid-url": "1.0.9"
@@ -1692,9 +1692,9 @@
           }
         },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
+          "integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -1712,9 +1712,9 @@
       }
     },
     "@graphql-tools/load-files": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load-files/-/load-files-6.0.8.tgz",
-      "integrity": "sha512-C0cG/XE2T2A8tBeUa3OchqY2cQ0vf7UqoHHMFKVpADdFRqSmWdayzfIEMYCenAqiAL8owSElCbSTCV3676B2AA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load-files/-/load-files-6.0.9.tgz",
+      "integrity": "sha512-KNiAM/X5ldfJcuHOthcGoosiwQgBW2tqjs8WnjDORCDdA5ZJ1XGxYGy04R30740LxxBQhCBZ1joQNJ5biFPWzA==",
       "requires": {
         "fs-extra": "9.0.1",
         "globby": "11.0.1",
@@ -1762,12 +1762,12 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.0.8.tgz",
-      "integrity": "sha512-CxMON945bQUDZ8WivP/1Bt7V1PgjpEqHQc/8UYeBXkUrUC/CKDhD270I13v/6njgImagdBHGgwS9r6cs785eWg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.0.9.tgz",
+      "integrity": "sha512-aOYgziSQnlubdaCFuPS5MNu9hmhMMfl65xvkZN1k5L/kP6rGN6SyjfeUEEzveOFgIYJbYxQEoxySD9gBAm8PiQ==",
       "requires": {
-        "@graphql-tools/schema": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/schema": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1779,12 +1779,12 @@
       }
     },
     "@graphql-tools/mock": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-6.0.8.tgz",
-      "integrity": "sha512-arlOgQ5z0DySnQsEq1XThAC7z/B7yUri+r4nyI+mCz1CXcOK4tohVid6LI84Ujgjw6bDOL2xhFHQSAmSDsjfhQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-6.0.9.tgz",
+      "integrity": "sha512-ArnjFrHoTptsA1ZZIn5f88uUC97RM+VODaPqanfUYQ2uE/POZKBcb7wGPxcAx9mXesRKWJB3zD71LrBlF/xLpQ==",
       "requires": {
-        "@graphql-tools/schema": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/schema": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1796,11 +1796,11 @@
       }
     },
     "@graphql-tools/module-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/module-loader/-/module-loader-6.0.8.tgz",
-      "integrity": "sha512-BeMjGuZwUnWjT/1Oh8EojEkiZ+Z6990Via9WnUFfpbtspePMIFdp8Zt49d4TnnQvTLWhQPE+nqITkIxDrTbCKQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/module-loader/-/module-loader-6.0.9.tgz",
+      "integrity": "sha512-iyTAqGub8+SM0X6cFhqeEmRq7TAukGi1U2T6PbVDRmBThqZ7UYL9TsYKFaapSmHIEtVdFwMINDtGwJw/tOgMxw==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1812,29 +1812,29 @@
       }
     },
     "@graphql-tools/relay-operation-optimizer": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.0.8.tgz",
-      "integrity": "sha512-ZP+HX0mLdkaYIsZtH904WJtOYEFPxhy+vCsMAXRDsIE+9H4SPrslKvqhldLl5lpGnG/49r+Yu3M06nXaf3jsgg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.0.9.tgz",
+      "integrity": "sha512-8TysXdOKOKVsRZNy80X+lzzuumwqtc23FaWDxpoBDidFq408QxJaA8NMrThiOxz/TjesVI/MDESfjizMcvwJUg==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "relay-compiler": "9.1.0"
       }
     },
     "@graphql-tools/resolvers-composition": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/resolvers-composition/-/resolvers-composition-6.0.8.tgz",
-      "integrity": "sha512-1mA7Z5uV3XUeUtXECZneiYUTzfPhtIvTaiTdemZUs+Vf8F0zYROBxn87AmosH9QLjauGVftdfOzgTlWiMXIhVA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/resolvers-composition/-/resolvers-composition-6.0.9.tgz",
+      "integrity": "sha512-HFLSkSMRbLpVYKpRMhSj7NnLP9oDUyFvVm1drj7a/0oqxiih5KJ6UhiuuJnudIpHuVG+J7yNbhL4q2Ivp0t/lg==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "lodash": "4.17.15"
       }
     },
     "@graphql-tools/schema": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.0.8.tgz",
-      "integrity": "sha512-DCypfqU1UJTgFGRTgoSTbrfYVZy3ZjRlNn8HYOjCB2Og2nUsl+WxBrWRmCD+X+cK3qhH+gYZor0SlDxyOMDq9w==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.0.9.tgz",
+      "integrity": "sha512-lemY+UeZRVmMYPvszCKvPfaR+R0dR2FgqjhESzlNWBbLhHuCewilTzYuQ+A+o8hQxdtPGIHfNPGf6A0ZZ70jWw==",
       "requires": {
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1846,14 +1846,14 @@
       }
     },
     "@graphql-tools/stitch": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-6.0.8.tgz",
-      "integrity": "sha512-Tr7AjTdPM4rQepYC1UBn31KsGprLzbFJdgb6bC1Ua/j1PlbHdNOtfwF2LlrkvTgdDTJnRC8jbeG85ZzTGyjqvw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-6.0.9.tgz",
+      "integrity": "sha512-jhh+gXQ0fy+SkC3ahIFeRfCZzug3+vWxXnajflSdmak8J4u0wLF2Wg/aCn1Kynv66Xi+Sf/0k5EcrkBOWP0bng==",
       "requires": {
-        "@graphql-tools/delegate": "6.0.8",
-        "@graphql-tools/schema": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
-        "@graphql-tools/wrap": "6.0.8",
+        "@graphql-tools/delegate": "6.0.9",
+        "@graphql-tools/schema": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
+        "@graphql-tools/wrap": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1865,13 +1865,13 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.0.8.tgz",
-      "integrity": "sha512-iQtC8lz6ef9j3wtXPtrE3gZtE4DciX9q64tHx+/60UMyBj6zw0kL+z0OpbaBowzNiherahgqSmpDsM2s8jEgAA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.0.9.tgz",
+      "integrity": "sha512-Iaw8ntJYAI/ARNL6ngEXbjrKxzJzimnsM9afvSf6gamD776lkCn/3ULz8Ob+3lvQbMliEdiit3jLCopSbKJ8vQ==",
       "requires": {
-        "@graphql-tools/delegate": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
-        "@graphql-tools/wrap": "6.0.8",
+        "@graphql-tools/delegate": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
+        "@graphql-tools/wrap": "6.0.9",
         "@types/websocket": "1.0.0",
         "cross-fetch": "3.0.4",
         "subscriptions-transport-ws": "0.9.16",
@@ -1907,21 +1907,21 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.0.8.tgz",
-      "integrity": "sha512-1Idtq70pocuivrFUV2E+7o3ikyEUvES9i+YzQcNRoC04J29NWIiqJawjaWyLUt3z3/xdb6BEDpCwEy2Spu0CFQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.0.9.tgz",
+      "integrity": "sha512-WtX+t64SCN9VejKA/gdtm2sHPOX8D1G1tAyrrKH7hnh6RaCmQwYkhs/f6tBnTTYOIBy7yVYNoXzqiv/tmOkAOQ==",
       "requires": {
         "camel-case": "4.1.1"
       }
     },
     "@graphql-tools/wrap": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-6.0.8.tgz",
-      "integrity": "sha512-vv8BZiiOyZjORHzMOMIhZRIBEGcc3o/OnmVlgPudYvDMgILfXxMSlXVx3LIx7LHqzbrDfgP4KWfcKwuIcezTSA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-6.0.9.tgz",
+      "integrity": "sha512-tvygPTfI8DcbT1rJ45dqkpbF6xYxy3/54yvrzgHJc674clAI9q98i16mql9iso3Rc9oSEt1CWUugmrNqgcgWrA==",
       "requires": {
-        "@graphql-tools/delegate": "6.0.8",
-        "@graphql-tools/schema": "6.0.8",
-        "@graphql-tools/utils": "6.0.8",
+        "@graphql-tools/delegate": "6.0.9",
+        "@graphql-tools/schema": "6.0.9",
+        "@graphql-tools/utils": "6.0.9",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -2968,11 +2968,6 @@
           }
         }
       }
-    },
-    "@kwsites/exec-p": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@kwsites/exec-p/-/exec-p-0.4.0.tgz",
-      "integrity": "sha512-44DWNv5gDR9EwrCTVQ4ZC99yPqVS0VCWrYIBl45qNR8XQy+4lbl0IQG8kBDf6NHwj4Ib4c2z1Fq1IUJOCbkZcw=="
     },
     "@mdx-js/mdx": {
       "version": "1.6.5",
@@ -5227,9 +5222,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.9.3.tgz",
-      "integrity": "sha512-EfMoizTX4/aUVN/cbWCU+uythWT5Xjh29npZnyTwBL2b16JH7WM9vbVMJQoCi+26HfRpKJS6SJfDcUT12wc3Mg=="
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.9.5.tgz",
+      "integrity": "sha512-z0T2dMz6V8a8hC11NFDwnuT5xR0k4Vu4Zie4A5BPchQOe59uHpbaM54mMl66FUA/iLTfYC11xez1N3Wc1gV20w=="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -5302,6 +5297,7 @@
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.4.8.tgz",
       "integrity": "sha512-U2Ex9XKYk2SbSabZIvQ/r5aKzrQibmxtyZ1SxGC0HNsjLU1QdWCCs+jeoiClWyi036y/4wmvHTxPjOOM2KdIZQ==",
+      "dev": true,
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.10.1",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
@@ -9937,9 +9933,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.23.1.tgz",
-      "integrity": "sha512-PFl8uTeA9D1HolCOSbaFSYTf6nG0DcSghe3fXrYLD4daov4IYGzM6+eGQkVNFwBbFEZod/7QzA4r1Rx6awkZDw==",
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.23.3.tgz",
+      "integrity": "sha512-uVRJUQuTga7GMag9Rrb+3amjSVoGDPgSTXivhDXW/TzR5ouBr6/rudjcDTruRwFnKsAwUExrYMMXPRCwkMFctQ==",
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/core": "^7.10.2",
@@ -9963,8 +9959,8 @@
         "babel-loader": "^8.1.0",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "babel-plugin-remove-graphql-queries": "^2.9.3",
-        "babel-preset-gatsby": "^0.4.8",
+        "babel-plugin-remove-graphql-queries": "^2.9.5",
+        "babel-preset-gatsby": "^0.4.9",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
         "bluebird": "^3.7.2",
@@ -10003,15 +9999,15 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-admin": "^0.1.65",
-        "gatsby-cli": "^2.12.44",
-        "gatsby-core-utils": "^1.3.4",
-        "gatsby-graphiql-explorer": "^0.4.4",
-        "gatsby-link": "^2.4.5",
-        "gatsby-plugin-page-creator": "^2.3.8",
-        "gatsby-plugin-typescript": "^2.4.4",
-        "gatsby-react-router-scroll": "^3.0.2",
-        "gatsby-telemetry": "^1.3.10",
+        "gatsby-admin": "^0.1.67",
+        "gatsby-cli": "^2.12.45",
+        "gatsby-core-utils": "^1.3.5",
+        "gatsby-graphiql-explorer": "^0.4.5",
+        "gatsby-link": "^2.4.6",
+        "gatsby-plugin-page-creator": "^2.3.9",
+        "gatsby-plugin-typescript": "^2.4.6",
+        "gatsby-react-router-scroll": "^3.0.3",
+        "gatsby-telemetry": "^1.3.11",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.6.0",
@@ -10092,6 +10088,26 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
+        "babel-preset-gatsby": {
+          "version": "0.4.9",
+          "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.4.9.tgz",
+          "integrity": "sha512-Jh8d7d36O2G/bTofQohOuEPBbGwDY6JftiC2U4LCtnZ4WILCvMSnf1DvIP6Y9ZDNuVy8ETb2AzmAfW1Ys6jA1Q==",
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.10.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.10.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.10.1",
+            "@babel/plugin-transform-spread": "^7.10.1",
+            "@babel/preset-env": "^7.10.2",
+            "@babel/preset-react": "^7.10.1",
+            "@babel/runtime": "^7.10.2",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "babel-plugin-macros": "^2.8.0",
+            "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+            "gatsby-core-utils": "^1.3.5"
+          }
+        },
         "eslint-plugin-flowtype": {
           "version": "3.13.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
@@ -10106,9 +10122,9 @@
           "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
         },
         "gatsby-cli": {
-          "version": "2.12.44",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.12.44.tgz",
-          "integrity": "sha512-7cGZHSt/YFL6q68Cst7qnthYMckzP8zlNTkKQH24hm/vMHUusvl2vPONJL4XbyLZwnQ3tts44B2eMGK4Qoa5Rg==",
+          "version": "2.12.45",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.12.45.tgz",
+          "integrity": "sha512-CY0ltZ5DvrSo30MkPcU2FFGiCrQUjirXAY7TdFEhc8IeV5Gj9E2AFmUF1FO4Dna6yv47WBBaHKFpsiKc5Iq0XA==",
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/runtime": "^7.10.2",
@@ -10125,9 +10141,9 @@
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.3.4",
-            "gatsby-recipes": "^0.1.38",
-            "gatsby-telemetry": "^1.3.10",
+            "gatsby-core-utils": "^1.3.5",
+            "gatsby-recipes": "^0.1.39",
+            "gatsby-telemetry": "^1.3.11",
             "hosted-git-info": "^3.0.4",
             "ink": "^2.7.1",
             "ink-spinner": "^3.0.1",
@@ -10159,6 +10175,19 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.5.tgz",
+          "integrity": "sha512-kbwJ5BeQ8OixJVuBb1AGRL6vdkFz9nFBa6gXqjQ6AAXHhYDrjOYrRMIENT1QLoabWo6tlh0Hyl1agfWaQwW8lg==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "configstore": "^5.0.1",
+            "fs-extra": "^8.1.0",
+            "node-object-hash": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "xdg-basedir": "^4.0.0"
           }
         },
         "hosted-git-info": {
@@ -10203,9 +10232,9 @@
       }
     },
     "gatsby-admin": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/gatsby-admin/-/gatsby-admin-0.1.65.tgz",
-      "integrity": "sha512-9pwJA4kSMAfQ3xOC/xAGIRY4va515R49EsoWza63UR9vusbrjBOUdqyzCgZhqyhp47sUGr/urrfsbWttqoVOBw==",
+      "version": "0.1.67",
+      "resolved": "https://registry.npmjs.org/gatsby-admin/-/gatsby-admin-0.1.67.tgz",
+      "integrity": "sha512-8TCI6TEycyb3qWmrRm6GieCMVsNnuAkbMXwl8grg5Vyi0UA2oGxilTTwfQERjLNfpsPpuI0rn0197clgYZCwQA==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@emotion/styled": "^10.0.27",
@@ -10213,10 +10242,10 @@
         "@typescript-eslint/parser": "^2.28.0",
         "csstype": "^2.6.10",
         "formik": "^2.1.4",
-        "gatsby": "^2.23.1",
+        "gatsby": "^2.23.3",
         "gatsby-interface": "0.0.167",
-        "gatsby-plugin-typescript": "^2.4.4",
-        "gatsby-source-graphql": "^2.5.3",
+        "gatsby-plugin-typescript": "^2.4.6",
+        "gatsby-source-graphql": "^2.5.4",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
         "react-helmet": "^6.0.0",
@@ -10251,9 +10280,9 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.4.4.tgz",
-      "integrity": "sha512-9WLWrE7DUOFJ9PQ1ntEQceC0z9JEndRANTkpCTB7MWEBL/fvuj6+oDgmpW/eJPT2KkMuAP+g4o5bKld52MneRA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.4.5.tgz",
+      "integrity": "sha512-5ykkwnMhmIAzcxvVCnvYEk8HmEoFDZLeRET3Ug4sCthYvfucqzG6JJ3RuMGhPElu6Sat0vSS6XKwQ5EPu/sWTA==",
       "requires": {
         "@babel/runtime": "^7.10.2"
       }
@@ -10308,9 +10337,9 @@
       }
     },
     "gatsby-link": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.4.5.tgz",
-      "integrity": "sha512-h684vfaHkvkU4m18ExQWKA/iU/nDQ4SpQf5wsY7aWB7iHKS1Orxd2Ol9d9ndv1qi4WyUncgl66uqbDC29BegQg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.4.6.tgz",
+      "integrity": "sha512-jOYEJa860KHcVOZ/6gjMv2EnCG7StdD4mLEGEMcEC8mzn4PWHQXHYsGdXcOvjn6SaqJ888hWuYjik5Jm8xW+cg==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "@types/reach__router": "^1.3.3",
@@ -10318,18 +10347,33 @@
       }
     },
     "gatsby-page-utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.2.8.tgz",
-      "integrity": "sha512-LlWDt8Eg6hB5RM601f1P7L2NQ17m4//n+OtMwNpSYjhgklyCw2JHmDWj8fqEGjyMYFLbFFiVurCiYqBbvtc2ng==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.2.9.tgz",
+      "integrity": "sha512-Mh3QbDdKKrvbJRHtMsBvo+sDTaGfcTiXCFGTkFu2VbL3P6mZySFJ8fDLb9SbQvwvMVw/vD5IZT1KJerfmgfvGQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "bluebird": "^3.7.2",
         "chokidar": "3.4.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.3.4",
+        "gatsby-core-utils": "^1.3.5",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.5.tgz",
+          "integrity": "sha512-kbwJ5BeQ8OixJVuBb1AGRL6vdkFz9nFBa6gXqjQ6AAXHhYDrjOYrRMIENT1QLoabWo6tlh0Hyl1agfWaQwW8lg==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "configstore": "^5.0.1",
+            "fs-extra": "^8.1.0",
+            "node-object-hash": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "xdg-basedir": "^4.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-chakra-ui": {
@@ -10363,14 +10407,14 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.8.tgz",
-      "integrity": "sha512-qREefPFXGg6HY5TVhtKFyhrolKfz4vygdBdpDnhxhDVwBNvT49GSzEXZDgNBFJrd4OzZ5CoI4Z38I/Mxz1760A==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.9.tgz",
+      "integrity": "sha512-ZNfjSoJ3AyACP5FWo0rwoeuIoZdD58le7oCmcVHVks/KOS/pJVGn8GwcrHE6xxCNM4KzqdfNBGZVyM+7RUASyA==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.2.8",
+        "gatsby-page-utils": "^0.2.9",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
@@ -10393,9 +10437,9 @@
       }
     },
     "gatsby-plugin-typescript": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.4.4.tgz",
-      "integrity": "sha512-BWTqUEQ70DrqXQIEE5hl+0NK19ggDLksGZdt4OYJF3cFUmYn6sNhYu9cvKLcj4DLSxFVe1fJl7vK9n0HLdCwRA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.4.6.tgz",
+      "integrity": "sha512-RfI2/k5XHmyNHjKDZDEPha/TNoY0Wh6zeBteqmidoPsJ2GfeFhyyxFxuRak+wYpZqdMh/aVwaJoF9Q1OiS4woQ==",
       "requires": {
         "@babel/core": "^7.10.2",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
@@ -10403,13 +10447,13 @@
         "@babel/plugin-proposal-optional-chaining": "^7.10.1",
         "@babel/preset-typescript": "^7.10.1",
         "@babel/runtime": "^7.10.2",
-        "babel-plugin-remove-graphql-queries": "^2.9.3"
+        "babel-plugin-remove-graphql-queries": "^2.9.5"
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.0.2.tgz",
-      "integrity": "sha512-1W+16VxanVJ7RD3LmT0EgpUa7n/GgleJmcHg7ujcI7c2gvroJCTlRKxmu5VB6kVFSlZvUh3KPHdBqKxhPsU0DQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.0.3.tgz",
+      "integrity": "sha512-VwwF1kmehIbjZek5MeMvf3SySoJUbUhQVQIsteWLqOPU3shz7b1sLpcLu3o0knUn7ml+8NB3rG2Yjb0a/LPBpA==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "scroll-behavior": "^0.9.12",
@@ -10427,9 +10471,9 @@
       }
     },
     "gatsby-recipes": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.1.38.tgz",
-      "integrity": "sha512-Mly2n47VL0XfiAcK07+ZQvdOAFyYl3TH8cIApOpkJZCMSE0/Zmaz4rpD0W33ZXe2yIDnlVJkQPNDjAdYHN8ePA==",
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.1.39.tgz",
+      "integrity": "sha512-Pf8EGKhCAv4E1rU0NL6pKH9mC8QB/0pW/9oAAb9Rs2N3TeBYcQ36hQP95ana63GZwY35eKoFzjdWGHmegQw90Q==",
       "requires": {
         "@babel/core": "^7.10.2",
         "@babel/generator": "^7.10.2",
@@ -10452,8 +10496,8 @@
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.3.4",
-        "gatsby-telemetry": "^1.3.10",
+        "gatsby-core-utils": "^1.3.5",
+        "gatsby-telemetry": "^1.3.11",
         "glob": "^7.1.6",
         "graphql": "^14.6.0",
         "graphql-compose": "^6.3.8",
@@ -10548,6 +10592,19 @@
             "path-exists": "^4.0.0"
           }
         },
+        "gatsby-core-utils": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.5.tgz",
+          "integrity": "sha512-kbwJ5BeQ8OixJVuBb1AGRL6vdkFz9nFBa6gXqjQ6AAXHhYDrjOYrRMIENT1QLoabWo6tlh0Hyl1agfWaQwW8lg==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "configstore": "^5.0.1",
+            "fs-extra": "^8.1.0",
+            "node-object-hash": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
         "get-stream": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
@@ -10557,31 +10614,31 @@
           }
         },
         "graphql-tools": {
-          "version": "6.0.8",
-          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-6.0.8.tgz",
-          "integrity": "sha512-/zfzAN5Ifux4oMzIkEK6EdYdVDzYu0a9rxCVk+GhpodnsLXmkg+J/SnisPlrCwYiT6QRRMpmQX3Cce3dRViI6w==",
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-6.0.9.tgz",
+          "integrity": "sha512-hmCm6Zn8k3mLDi+/F0BXSnvF2EUtIqqjxhQTG2hvawUeGhsH3YNu+fsRtBWmXTLqt2nEfLSTxKMJVjFFXAZNFw==",
           "requires": {
-            "@graphql-tools/code-file-loader": "6.0.8",
-            "@graphql-tools/delegate": "6.0.8",
-            "@graphql-tools/git-loader": "6.0.8",
-            "@graphql-tools/github-loader": "6.0.8",
-            "@graphql-tools/graphql-file-loader": "6.0.8",
-            "@graphql-tools/graphql-tag-pluck": "6.0.8",
-            "@graphql-tools/import": "6.0.8",
-            "@graphql-tools/json-file-loader": "6.0.8",
-            "@graphql-tools/links": "6.0.8",
-            "@graphql-tools/load": "6.0.8",
-            "@graphql-tools/load-files": "6.0.8",
-            "@graphql-tools/merge": "6.0.8",
-            "@graphql-tools/mock": "6.0.8",
-            "@graphql-tools/module-loader": "6.0.8",
-            "@graphql-tools/relay-operation-optimizer": "6.0.8",
-            "@graphql-tools/resolvers-composition": "6.0.8",
-            "@graphql-tools/schema": "6.0.8",
-            "@graphql-tools/stitch": "6.0.8",
-            "@graphql-tools/url-loader": "6.0.8",
-            "@graphql-tools/utils": "6.0.8",
-            "@graphql-tools/wrap": "6.0.8"
+            "@graphql-tools/code-file-loader": "6.0.9",
+            "@graphql-tools/delegate": "6.0.9",
+            "@graphql-tools/git-loader": "6.0.9",
+            "@graphql-tools/github-loader": "6.0.9",
+            "@graphql-tools/graphql-file-loader": "6.0.9",
+            "@graphql-tools/graphql-tag-pluck": "6.0.9",
+            "@graphql-tools/import": "6.0.9",
+            "@graphql-tools/json-file-loader": "6.0.9",
+            "@graphql-tools/links": "6.0.9",
+            "@graphql-tools/load": "6.0.9",
+            "@graphql-tools/load-files": "6.0.9",
+            "@graphql-tools/merge": "6.0.9",
+            "@graphql-tools/mock": "6.0.9",
+            "@graphql-tools/module-loader": "6.0.9",
+            "@graphql-tools/relay-operation-optimizer": "6.0.9",
+            "@graphql-tools/resolvers-composition": "6.0.9",
+            "@graphql-tools/schema": "6.0.9",
+            "@graphql-tools/stitch": "6.0.9",
+            "@graphql-tools/url-loader": "6.0.9",
+            "@graphql-tools/utils": "6.0.9",
+            "@graphql-tools/wrap": "6.0.9"
           }
         },
         "is-binary-path": {
@@ -10751,9 +10808,9 @@
       }
     },
     "gatsby-source-graphql": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/gatsby-source-graphql/-/gatsby-source-graphql-2.5.3.tgz",
-      "integrity": "sha512-6WiEdyCpjFKFUzWvY26jrQUF3sBg5F0cpVLndJtSMtwvv6GYeiqllhMC2f8ygGYZvUVBCq1NHN/5Z/wGd0d0ww==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/gatsby-source-graphql/-/gatsby-source-graphql-2.5.4.tgz",
+      "integrity": "sha512-lP8/GS6f1SMQXa4q72iH/CAAZQ/RxwgADPdFSAZS8e7fNkdlhUYpUqY69mdmQxwv5iMqaHMVQTdQmuiKcyQYXg==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "apollo-link": "1.2.14",
@@ -10778,9 +10835,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.10.tgz",
-      "integrity": "sha512-Lp2DJhuPh5f5swYfIMcSYfXMi1bdoiO8Z2b3ZW2m+mDZk77dwEQg3dZPXlLyHGxboiO0D8Q7Jz6Fin9mO0T3CA==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.11.tgz",
+      "integrity": "sha512-k5bzy0G0Me0aQYaW1cOWp0PQ9+wRXHU0lbztdinnRAWlqqb3EGMVPtfUhP7aMJvXtj3UfLy3pk0xBfsX8BHvfA==",
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/runtime": "^7.10.2",
@@ -10789,7 +10846,7 @@
         "configstore": "^5.0.1",
         "envinfo": "^7.5.1",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.3.4",
+        "gatsby-core-utils": "^1.3.5",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -10801,6 +10858,19 @@
         "uuid": "3.4.0"
       },
       "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.5.tgz",
+          "integrity": "sha512-kbwJ5BeQ8OixJVuBb1AGRL6vdkFz9nFBa6gXqjQ6AAXHhYDrjOYrRMIENT1QLoabWo6tlh0Hyl1agfWaQwW8lg==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "configstore": "^5.0.1",
+            "fs-extra": "^8.1.0",
+            "node-object-hash": "^2.0.0",
+            "proper-lockfile": "^4.1.1",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
         "node-fetch": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -20440,9 +20510,9 @@
       }
     },
     "remark-stringify": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.0.0.tgz",
-      "integrity": "sha512-cABVYVloFH+2ZI5bdqzoOmemcz/ZuhQSH6W6ZNYnLojAUUn3xtX7u+6BpnYp35qHoGr2NFBsERV14t4vCIeW8w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.0.tgz",
+      "integrity": "sha512-FSPZv1ds76oAZjurhhuV5qXSUSoz6QRPuwYK38S41sLHwg4oB7ejnmZshj7qwjgYLf93kdz6BOX9j5aidNE7rA==",
       "requires": {
         "ccount": "^1.0.0",
         "is-alphanumeric": "^1.0.0",
@@ -21085,23 +21155,9 @@
       "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo="
     },
     "simple-git": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.5.0.tgz",
-      "integrity": "sha512-4gmtMqfIL9bsBNJDP/rDwZe3GsQL/tp85Qv5cmRc8iIDNOZJS4IX1oPfcqp9b7BGPc5bfuw4yd1i3lQacvuqDQ==",
-      "requires": {
-        "@kwsites/exec-p": "^0.4.0",
-        "debug": "^4.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.6.0.tgz",
+      "integrity": "sha512-eplWRfu6RTfoAzGl7I0+g06MvYauXaNpjeuhFiOYZO9hevnH54RkkStOkEevWwqBWfdzWNO9ocffbdtxFzBqXQ=="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@reach/visually-hidden": "0.10.2",
     "dotenv": "^8.2.0",
     "emotion-theming": "^10.0.27",
-    "gatsby": "^2.22.20",
+    "gatsby": "^2.23.3",
     "gatsby-plugin-chakra-ui": "^0.1.4",
     "gatsby-plugin-facebook-pixel": "^1.0.3",
     "gatsby-plugin-google-tagmanager": "^2.3.4",


### PR DESCRIPTION
# Describe your PR
Updates Gatsby to the latest version to ensure that the graphql-playground-html dependency is on version 1.6.22 or later

Fixes #86 
