### PR TITLE
Fix/update image props

### DIFF
--- a/src/components/ContentBlock.js
+++ b/src/components/ContentBlock.js
@@ -97,7 +97,6 @@ const LeftSideContentBlock = ({
         right="0"
       >
         <Image
-          cloudName="rebuild-black-business"
           publicId={imageSource}
           transforms={{
             fetchFormat: 'auto',
@@ -131,7 +130,6 @@ const LeftSideContentBlock = ({
         textAlign={['center', 'center', 'left']}
       >
         <Image
-          cloudName="rebuild-black-business"
           publicId={imageSource}
           transforms={{
             fetchFormat: 'auto',
@@ -193,7 +191,6 @@ const RightSideContentBlock = ({
         textAlign={['center', 'center', 'left']}
       >
         <Image
-          cloudName="rebuild-black-business"
           publicId={imageSource}
           transforms={{
             fetchFormat: 'auto',
@@ -225,7 +222,6 @@ const RightSideContentBlock = ({
         textAlign={['center', 'center', 'left']}
       >
         <Image
-          cloudName="rebuild-black-business"
           publicId={imageSource}
           transforms={{
             fetchFormat: 'auto',
@@ -269,7 +265,6 @@ const FullWidthContentBlock = ({
   return (
     <ContentBlockWrapper imageSource={imageSource}>
       <Image
-        cloudName="rebuild-black-business"
         publicId={imageSource}
         transforms={{
           fetchFormat: 'auto',

--- a/src/components/Feeds/AllyFeed.js
+++ b/src/components/Feeds/AllyFeed.js
@@ -82,7 +82,6 @@ const AllyFeed = props => {
                     pos="relative"
                   >
                     <Image
-                      cloudName="rebuild-black-business"
                       publicId="assets/ally-sign-up"
                       transforms={{
                         fetchFormat: 'auto',

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -3,9 +3,11 @@ import { useImage } from 'use-cloudinary';
 import { Image as ChakraImage } from '@chakra-ui/core';
 
 export default function Image(props) {
-  const { cloudName, transforms, publicId, alt } = props;
+  const { transforms, publicId, alt, src } = props;
 
-  const { getImage, data, status, error } = useImage({ cloud_name: cloudName });
+  const { getImage, data, status, error } = useImage({
+    cloud_name: 'rebuild-black-business',
+  });
 
   /* eslint-disable react-hooks/exhaustive-deps */
   React.useEffect(() => {
@@ -24,20 +26,5 @@ export default function Image(props) {
   // @TODO :: Deliver custom Error UI if needed
   if (status === 'error') return <p>{error.message}</p>;
 
-  return <ChakraImage {...props} src={data} alt={alt} />;
+  return <ChakraImage {...props} src={data || src} alt={alt} />;
 }
-
-/*
-  Image Component in use
-
-  <Image
-    cloudName="rebuild-black-business"
-    publicId="samples/animals/three-dogs"
-    mt={10}
-    transforms={{
-      height: 0.3,
-      fetchFormat: 'auto',
-      quality: 'auto',
-    }}
-  />
-*/

--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -81,7 +81,6 @@ const PrimaryNav = forwardRef(
         >
           <Link as={GatsbyLink} to="/">
             <Image
-              cloudName="rebuild-black-business"
               publicId="assets/RBBLogoFinal_ugdskx"
               transforms={{
                 height: 0.1,

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -46,7 +46,6 @@ export default function Search() {
         {data &&
           data.resources.map(image => (
             <Image
-              cloudName="rebuild-black-business"
               border="2px solid black"
               publicId={image.public_id}
               options={{ height: 0.2 }}


### PR DESCRIPTION
# Describe your PR
Adding a `src` prop to the image component so we can either use Cloudinary or a basic `src` URL or local asset

## Steps to test

1. Go to all pages using the `<Image />` component to make sure non are broken from removing `cloudName` prop
2. Call the `Image` component with a URL to make sure it renders without the `publicId` prop

