### PR TITLE
fix: tests were failing due to multiple elements being returned by th…

### DIFF
--- a/cypress/integration/navigation.test.js
+++ b/cypress/integration/navigation.test.js
@@ -1,24 +1,28 @@
 /// <reference types="Cypress" />
 
-describe('Navigation tests', () => {
+describe('Header Navigation tests, non-mobile', () => {
   beforeEach(() => {
     cy.visit('/');
   });
 
   it('Clicking "About" navigates user to the about page', () => {
-    cy.get("a[href$='/about']").click();
+    cy.get('#navigation').findByText(/about/i).click();
 
     cy.url().should('include', '/about');
   });
 
   it('Clicking "Businesses" navigates user to the businesses page', () => {
-    cy.get("a[href$='/businesses']").click();
+    cy.get('#navigation')
+      .findByText(/businesses/i)
+      .click();
 
     cy.url().should('include', '/businesses');
   });
 
   it('Clicking "Allies" navigates user to the allies page', () => {
-    cy.get("a[href$='/allies']").click();
+    cy.get('#navigation')
+      .findByText(/allies/i)
+      .click();
 
     cy.url().should('include', '/allies');
   });


### PR DESCRIPTION
# Describe your PR
Tests were failing due to multiple elements being returned by the selector; refactored test to look for the header (on non-mobile size) and then by text since a user is going to look for the text of the link vs the selector

Doesn't fully fix the following issue, but does fix the navigation tests.

Related to #88
Fixes #88 

## Pages/Interfaces that will change
n/a

## Steps to test

1. `npm run test:e2e`

### Additional notes
