### PR TITLE
fixed copyright mobile text

### DIFF
--- a/src/components/footer/Copyright.js
+++ b/src/components/footer/Copyright.js
@@ -8,7 +8,11 @@ const Copyright = () => {
   const theme = useTheme();
   return (
     <Flex w="full" justify="center" align="center">
-      <Flex w={['80%', '80%', '80%', 'full']} textAlign="center">
+      <Flex
+        w={['80%', '80%', '80%', 'full']}
+        textAlign="center"
+        direction={['column', 'column', 'column', 'row']}
+      >
         <Text
           fontSize="12px"
           fontFamily={theme.fonts.heading}


### PR DESCRIPTION
This PR fixes how the copyright text is rendered on mobile view. 

## Pages/Interfaces that will change

All pages

### Screenshots / video of changes

![copyright-FIX](https://user-images.githubusercontent.com/22930449/84182550-dee54e80-aa8a-11ea-8d6f-94069846f924.PNG)


## Steps to test

Get local dev up and running and check mobile view via dev tools

