### PR TITLE
Changed breakpoint to fit 768px width screen size

### DIFF
--- a/src/gatsby-plugin-chakra-ui/theme.js
+++ b/src/gatsby-plugin-chakra-ui/theme.js
@@ -32,7 +32,7 @@ const customTheme = {
   },
   // Mobile views were not covered under default 'sm' breakpoint
   // Going to just write in mock sizes, but open to changing them
-  breakpoints: ['16em', '48em', '64em', '80em'],
+  breakpoints: ['16em', '56em', '64em', '80em'],
   fontWeights: {
     bold: 'bold',
   },


### PR DESCRIPTION
# Describe your PR

Related to https://github.com/Rebuild-Black-Business/RBB-Website/pull/77
Fixes https://trello.com/c/bPyeHOwL/68-header-nav-breakpoint

## Pages/Interfaces that will change
- 768px width breakpoint devices (mainly iPads)

### Screenshots / video of changes
**Before**
<img width="600" alt="Screen Shot 2020-06-09 at 11 24 23 AM" src="https://user-images.githubusercontent.com/8335579/84185778-6065be00-aa44-11ea-9865-3a9d505f278a.png">
**After**
<img width="389" alt="Screen Shot 2020-06-09 at 11 24 31 AM" src="https://user-images.githubusercontent.com/8335579/84185793-6491db80-aa44-11ea-95a2-aeb854ee982d.png">

