### PR TITLE
Fix: Remove italics from Allies card + Set homepage button length 

### DIFF
--- a/src/components/Cards/AllyCard.js
+++ b/src/components/Cards/AllyCard.js
@@ -109,7 +109,7 @@ const AllyCard = forwardRef(
               </CardButton>
             </CardButtonGroup>
             <Box marginTop="auto" paddingTop={theme.spacing.base}>
-              <Text as="small" fontSize="sm" fontStyle="italic" mt={3} isInline>
+              <Text as="small" fontSize="sm" mt={3} isInline>
                 <Icon
                   name="flag"
                   color={theme.colors['rbb-gray']}

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -137,7 +137,7 @@ const ResultCard = forwardRef(
               </CardButton>
             )}
           </CardButtonGroup>
-          <Text as="small" fontSize="sm" fontStyle="italic" mt={3}>
+          <Text as="small" fontSize="sm" mt={3}>
             <Link href="#">Report or update</Link>
           </Text>
         </CardContent>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -111,7 +111,7 @@ export default () => {
               </Text>
             </Box>
             <ButtonGroup spacing={4} mt={theme.spacing.base}>
-              <Button variant="primary" m={3} h="auto" px="30px">
+              <Button variant="primary" maxW="230px;" m={3} h="auto" px="30px">
                 Add Business
               </Button>
               <Button variant="secondary" m={3} h="auto" px="30px">
@@ -154,7 +154,7 @@ export default () => {
               </Text>
             </Box>
             <ButtonGroup spacing={4} mt={theme.spacing.base}>
-              <Button variant="primary" m={3} h="auto" px="30px">
+              <Button variant="primary" maxW="230px" m={3} h="auto" px="30px">
                 Add Business
               </Button>
               <Button variant="secondary" m={3} h="auto" px="30px">


### PR DESCRIPTION
# Describe your PR

Related to #
Fixes:
https://trello.com/c/S33OHugH/70-homepage-button-length
https://trello.com/c/kJSITB4E/83-allies-result-card-or-should-not-be-italicized

## Pages/Interfaces that will change
- Allies/Businesses page will be changed for italics
- Homepage will be changed for button length

### Screenshots / video of changes
### Button length
**Before**
<img width="531" alt="Screen Shot 2020-06-09 at 12 18 59 PM" src="https://user-images.githubusercontent.com/8335579/84192263-96a83b00-aa4e-11ea-80c9-e649c6fc90fe.png">
**After**
<img width="526" alt="Screen Shot 2020-06-09 at 12 19 03 PM" src="https://user-images.githubusercontent.com/8335579/84192274-99a32b80-aa4e-11ea-9ce7-2511f120e0c6.png">

### Italics
**Before**
<img width="176" alt="Screen Shot 2020-06-09 at 12 40 02 PM" src="https://user-images.githubusercontent.com/8335579/84192296-9f990c80-aa4e-11ea-9f0b-6e42b821e0fe.png">

**After**
<img width="184" alt="Screen Shot 2020-06-09 at 12 39 50 PM" src="https://user-images.githubusercontent.com/8335579/84192304-a3c52a00-aa4e-11ea-891b-9e2b53b21c72.png">

### Additional notes
