### PR TITLE
About Page card size responsive fixes

### DIFF
--- a/src/components/about/ContactCard.js
+++ b/src/components/about/ContactCard.js
@@ -96,8 +96,6 @@ const ModalCard = ({ publicId, modalTitle, title, blurb, margin }) => {
         as="a"
         href="#"
         ref={focusRef}
-        margin="1.5rem auto"
-        maxW={['279px', '342px']}
         maxH="322px"
         direction="column"
         onClick={onOpen}
@@ -115,8 +113,6 @@ const MailtoCard = ({ publicId, email, title, blurb }) => (
     as="a"
     href={`mailto:${email}`}
     isExternal
-    margin="1.5rem auto"
-    maxW={['279px', '342px']}
     maxH="322px"
     direction="column"
   >
@@ -129,8 +125,6 @@ const VolunteerCard = ({ publicId, title, blurb }) => (
     as={Link}
     href="https://discord.com/invite/272XMuv"
     isExternal
-    margin="1.5rem auto"
-    maxW={['279px', '342px']}
     maxH="322px"
     direction="column"
   >

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,4 +1,4 @@
-import { Flex, Heading, useTheme } from '@chakra-ui/core';
+import { Flex, Grid, Heading, useTheme } from '@chakra-ui/core';
 import React from 'react';
 import ContactCard from '../components/about/ContactCard';
 import Content from '../components/about/Content';
@@ -81,9 +81,13 @@ export default function About() {
           >
             CONTACT
           </Heading>
-          <Flex
+          <Grid
+            margin="0 auto"
+            maxWidth={theme.containers.main}
+            columnGap="24px"
+            rowGap="24px"
+            templateColumns="repeat(auto-fit, minmax(350px, 1fr))"
             w="100%"
-            direction={['column', 'column', 'row', 'row']}
             paddingTop="2rem"
             paddingBottom="2rem"
           >
@@ -106,7 +110,7 @@ export default function About() {
               blurb="Join our group chat in Discord"
               publicId="assets/contact-right"
             />
-          </Flex>
+          </Grid>
         </Flex>
       </Flex>
     </Layout>


### PR DESCRIPTION
# Describe your PR
Changes the layout of the cards on the bottom of the about page to a grid, with sensible minimum widths set, and a responsive layout

Related to [trello card](https://trello.com/c/NQlLfbwe/73-about-page-contact-card-spacing-too-far-apart-especially-on-wider-monitors)

## Pages/Interfaces that will change
/about

### Screenshots / video of changes
![image](https://user-images.githubusercontent.com/1844496/84192884-a2a0f680-aa68-11ea-88ee-64b4c25a2961.png)

mobile
![image](https://user-images.githubusercontent.com/1844496/84192994-c8c69680-aa68-11ea-843f-f0b6067f0518.png)

## Steps to test

1. pull up the deploy preview on this branch, and test `/about`

### Additional notes
