### PR TITLE
Feature/add loading component

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useImage } from 'use-cloudinary';
 import { Image as ChakraImage } from '@chakra-ui/core';
+import ImageSkeleton from './Loading/ImageSkeleton';
 
 export default function Image(props) {
   const { transforms, publicId, alt, src } = props;
@@ -20,8 +21,7 @@ export default function Image(props) {
   }, []);
   /* eslint-disable react-hooks/exhaustive-deps */
 
-  // @TODO :: Use`Spinner` or`Skeleton` component from Chakra UI here
-  if (status === 'loading') return <p>Loading...</p>;
+  if (status === 'loading') return <ImageSkeleton />;
 
   // @TODO :: Deliver custom Error UI if needed
   if (status === 'error') return <p>{error.message}</p>;

--- a/src/components/Loading/CardSkeleton.js
+++ b/src/components/Loading/CardSkeleton.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Skeleton, useTheme } from '@chakra-ui/core';
+
+/**
+ * Wraps content that parses data with a placeholder skeleton
+ */
+const CardSkeleton = ({ children, data }) => {
+  const [loading, setLoading] = React.useState(true);
+  const theme = useTheme();
+
+  React.useEffect(() => {
+    if (data.length) {
+      setLoading(false);
+    }
+  }, [data]);
+
+  return (
+    <Skeleton
+      isLoaded={!loading}
+      colorStart={theme.colors['rbb-result-card-grey']}
+      colorEnd={theme.colors['rbb-result-card-grey']}
+    >
+      {children}
+    </Skeleton>
+  );
+};
+
+export default CardSkeleton;

--- a/src/components/Loading/ImageSkeleton.js
+++ b/src/components/Loading/ImageSkeleton.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Skeleton } from '@chakra-ui/core';
+
+/**
+ * Image skeleton, shows before image is loaded on slower devices
+ * @param {string} height - The height of the image. Set to 100% by default
+ */
+const ImageSkeleton = ({ height = '100%' }) => {
+  return <Skeleton height={height} />;
+};
+
+export default ImageSkeleton;

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -9,7 +9,7 @@ import {
   CardButtonGroup,
   CardButton,
 } from './Card';
-import { Link, Text } from '@chakra-ui/core';
+import { Link, Text, useTheme } from '@chakra-ui/core';
 import { zipcodeConversion } from '../utils/locationUtils';
 
 // TODO: Replace with real fallback images for each category.
@@ -92,6 +92,7 @@ const ResultCard = forwardRef(
     const hasFallbackImage =
       category && Object.keys(categoryData).includes(category);
     const hasImage = !!(imageSrc || hasFallbackImage);
+    const theme = useTheme();
 
     // I'm not sure how categories are going to work, so this probaably needs to
     // change. Also unsure how we're going to handle the schema category on the
@@ -106,7 +107,7 @@ const ResultCard = forwardRef(
         ref={ref}
         {...props}
         // TODO: Use real theme colors per the design
-        border="1px solid gray"
+        border={`1px solid ${theme.colors['rbb-gray']}`}
         itemScope
         // TODO: the category in Airtable isn't going to match the schema
         // category, will need to be fixed. Omitting for now.
@@ -119,8 +120,11 @@ const ResultCard = forwardRef(
           />
         )}
         <CardContent
-          // TODO: Use real theme colors per the design
-          bg={hasImage ? 'white' : '#555'}
+          bg={
+            hasImage
+              ? theme.colors['rbb-white']
+              : theme.colors['rbb-result-card-grey']
+          }
           color={hasImage ? undefined : 'white'}
         >
           <CardHeading itemprop="name">{name}</CardHeading>

--- a/src/gatsby-plugin-chakra-ui/theme.js
+++ b/src/gatsby-plugin-chakra-ui/theme.js
@@ -67,6 +67,7 @@ const customTheme = {
     'rbb-white-100-alpha90': 'rgba(222, 222, 218, 0.9);',
     'rbb-red': '#BA2A2A',
     'rbb-orange': '#F46036',
+    'rbb-result-card-grey': '#555',
   },
   letterSpacings: {
     button: '0.05em',

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -47,7 +47,6 @@ export default function About() {
             marginBottom={['1.125rem', '1.125rem', 0, 0]}
             marginLeft={[0, 0, '5%', '15%', '15%', '30%']}
             marginRight={[0, 0, '5%', '20%', '22%', '35%']}
-            maxW="1200px"
           >
             <Content
               heading="MISSION"
@@ -89,7 +88,6 @@ export default function About() {
             rowGap="24px"
             templateColumns="repeat(auto-fit, minmax(350px, 1fr))"
             w="100%"
-            maxW="1400px"
             direction={['column', 'column', 'row', 'row']}
             paddingTop="2rem"
             paddingBottom="2rem"

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -47,6 +47,7 @@ export default function About() {
             marginBottom={['1.125rem', '1.125rem', 0, 0]}
             marginLeft={[0, 0, '5%', '15%', '15%', '30%']}
             marginRight={[0, 0, '5%', '20%', '22%', '35%']}
+            maxW="1200px"
           >
             <Content
               heading="MISSION"
@@ -83,6 +84,7 @@ export default function About() {
           </Heading>
           <Flex
             w="100%"
+            maxW="1400px"
             direction={['column', 'column', 'row', 'row']}
             paddingTop="2rem"
             paddingBottom="2rem"

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -2,10 +2,13 @@ import React from 'react';
 
 import { graphql, navigate } from 'gatsby';
 import { Flex } from '@chakra-ui/core';
-
 import { PageHero, Layout, BusinessFeed, Pagination } from '../components';
+import CardSkeleton from '../components/Loading/CardSkeleton';
 
 export default function Businesses(data) {
+  // AirTable passes us and extra data...
+  const businessFeedData = data.data.allAirtableBusinesses.nodes;
+
   const pageSubtitle = (
     <p>
       These business owners have been impacted during the protests. Your support
@@ -26,7 +29,10 @@ export default function Businesses(data) {
           heroImageUrl={heroBackgroundImageUrl}
           hasFadedHeroImage
         />
-        <BusinessFeed {...data} />
+        <CardSkeleton data={businessFeedData}>
+          <BusinessFeed {...data} />
+        </CardSkeleton>
+
         <Pagination
           onPageChanged={pagination =>
             navigate(


### PR DESCRIPTION
This PR adds a loading skeleton to the business page. It covers the whole grid as opposed to each card for user exp. Takes the color of the card as its placeholder color.

Also added a simple skeleton for image loading, its 100% height by default. 


Fixed the width on about page as it was too wide (1200px default) Added theme props to result card re: TODO

Related to #82
Fixes #82

## Pages/Interfaces that will change

Business and About

### Screenshots / video of changes

N/A - Screenshots wont replicate the behavior 

## Steps to test

Run locally - dev tools - throttle.
