### PR TITLE
Add page-specific photo credits

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -50,6 +50,11 @@ module.exports = {
     ],
     photoCreditLinks: [
       {
+        photographer: 'Clay Banks',
+        url: 'https://www.instagram.com/clay.banks',
+        pagePathname: '/',
+      },
+      {
         photographer: 'John Cameron',
         url: 'https://unsplash.com/@john_cameron',
         pagePathname: '/',
@@ -63,6 +68,46 @@ module.exports = {
         photographer: 'Mike Von',
         url: 'https://thevoncomplex.com',
         pagePathname: '/',
+      },
+      {
+        photographer: 'Kelly Lacy',
+        url: 'https://instagram.com/kellymlacy',
+        pagePathname: '/about',
+      },
+      {
+        photographer: 'WOCinTechChat.com',
+        url: 'http://www.wocintechchat.com/',
+        pagePathname: '/about',
+      },
+      {
+        photographer: 'Allison Christine',
+        url: 'https://www.instagram.com/happpyal/',
+        pagePathname: '/about',
+      },
+      {
+        photographer: 'Chris Slupski',
+        url: 'https://unsplash.com/@kslupski',
+        pagePathname: '/about',
+      },
+      {
+        photographer: 'Jason Leung',
+        url: 'https://www.instagram.com/xninjason/',
+        pagePathname: '/businesses',
+      },
+      {
+        photographer: 'Julian Myles',
+        url: 'https://julianmyles.nyc',
+        pagePathname: '/businesses',
+      },
+      {
+        photographer: 'Joe Yates',
+        url: 'https://www.instagram.com/josephyates_/',
+        pagePathname: '/allies',
+      },
+      {
+        photographer: 'Logan Weaver ',
+        url: 'https://lgnwvrphto.com',
+        pagePathname: '/allies',
       },
     ],
   },


### PR DESCRIPTION
This adds list of links and photographer names that will appear in the
footer for each page.

Relevant Trello card: https://trello.com/c/t9DmRiLj/78-add-photo-credits-to-the-sitemetadata

## Pages/Interfaces that will change

This should update each of the top-level pages to show relative photo credit links in the footer:

- Home: https://rebuild-black-business.netlify.app/
- About: https://rebuild-black-business.netlify.app/about
- Businesses: https://rebuild-black-business.netlify.app/businesses
- Allies: https://rebuild-black-business.netlify.app/allies

### Screenshots / video of changes

- Home: 
![image](https://user-images.githubusercontent.com/235503/84197613-1508db00-aa57-11ea-8c71-256c8fa18f09.png)
- About:
![image](https://user-images.githubusercontent.com/235503/84197749-4da8b480-aa57-11ea-859a-fe2237177318.png)
- Businesses: 
![image](https://user-images.githubusercontent.com/235503/84197760-54372c00-aa57-11ea-998f-8104c4e367de.png)
- Allies:
![image](https://user-images.githubusercontent.com/235503/84197777-59947680-aa57-11ea-9804-46192f8e7d40.png)


