### PR TITLE
Fixing hero bg image alignment

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -42,6 +42,7 @@ function getButtonStyles(theme, variant) {
 
 const Button = forwardRef(({ variant = 'primary', ...props }, ref) => {
   const theme = useTheme();
+  console.log(variant, props.children);
 
   if (!['cta', 'primary', 'secondary'].includes(variant))
     throw new Error(`Invalid <Button> variant: "${variant}"`);

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -42,7 +42,6 @@ function getButtonStyles(theme, variant) {
 
 const Button = forwardRef(({ variant = 'primary', ...props }, ref) => {
   const theme = useTheme();
-  console.log(variant, props.children);
 
   if (!['cta', 'primary', 'secondary'].includes(variant))
     throw new Error(`Invalid <Button> variant: "${variant}"`);

--- a/src/components/PageHero.js
+++ b/src/components/PageHero.js
@@ -14,12 +14,14 @@ const PageHero = ({ title, subtitle, heroImageUrl, hasFadedHeroImage }) => {
         <Box
           position="absolute"
           zIndex={-9}
+          left={0}
           top={0}
           width="100%"
           height="100vh"
           backgroundSize="cover"
           backgroundRepeat="no-repeat"
-          background={`${
+          backgroundPosition="top center"
+          backgroundImage={`${
             hasFadedHeroImage ? gradientFade : ''
           } url(${heroImageUrl})`}
         />

--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -1,12 +1,14 @@
 import React, { useState, useLayoutEffect, forwardRef } from 'react';
-import { useTheme } from '@chakra-ui/core';
-import { Flex, Link, Box } from '@chakra-ui/core';
 import { Link as GatsbyLink } from 'gatsby';
 import VisuallyHidden from '@reach/visually-hidden';
 import { Nav, NavMenu, NavItem, NavLink } from './Nav';
 import Image from './Image';
 import Button from '../components/Button';
 import {
+  Box,
+  Flex,
+  Link,
+  IconButton,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -15,6 +17,7 @@ import {
   ModalBody,
   ModalCloseButton,
   useDisclosure,
+  useTheme,
 } from '@chakra-ui/core';
 
 const INITIAL_TOGGLE_STATE = false;
@@ -51,7 +54,41 @@ const PrimaryNav = forwardRef(
         {...props}
       >
         <Box display={['block', 'block', 'none']} ml={{ sm: '5' }}>
-          <button
+          {isVisible ? (
+            // <VisuallyHidden>
+            //   {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
+            // </VisuallyHidden>
+            <IconButton
+              aria-label="Close"
+              icon="close"
+              size="lg"
+              title="close"
+              onClick={handleToggle}
+              background="transparent"
+            ></IconButton>
+          ) : (
+            <button
+              onClick={handleToggle}
+              aria-expanded={isVisible && !isMedium}
+              aria-controls="navigation"
+            >
+              <VisuallyHidden>
+                {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
+              </VisuallyHidden>
+              <svg
+                aria-hidden
+                width="32px"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+                fill={theme.colors['rbb-black-000']}
+              >
+                <title>Menu</title>
+
+                <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+              </svg>
+            </button>
+          )}
+          {/* <button
             onClick={handleToggle}
             aria-expanded={isVisible && !isMedium}
             aria-controls="navigation"
@@ -59,18 +96,29 @@ const PrimaryNav = forwardRef(
             <VisuallyHidden>
               {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
             </VisuallyHidden>
-            <svg
-              aria-hidden
-              width="30px"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-              fill={theme.colors['rbb-black-000']}
-            >
-              <title>Menu</title>
+            <Flex width="32px" height="32px" justify="center" align="center">
+              {isVisible ? (
+                <IconButton
+                  aria-label="Close"
+                  icon="close"
+                  size="30px"
+                  title="close"
+                />
+              ) : (
+                <svg
+                  aria-hidden
+                  width="32px"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill={theme.colors['rbb-black-000']}
+                >
+                  <title>Menu</title>
 
-              <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
-            </svg>
-          </button>
+                  <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+                </svg>
+              )}
+            </Flex> */}
+          {/* </button> */}
         </Box>
         <Flex
           align="center"

--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -55,9 +55,6 @@ const PrimaryNav = forwardRef(
       >
         <Box display={['block', 'block', 'none']} ml={{ sm: '5' }}>
           {isVisible ? (
-            // <VisuallyHidden>
-            //   {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
-            // </VisuallyHidden>
             <IconButton
               aria-label="Close"
               icon="close"
@@ -88,7 +85,7 @@ const PrimaryNav = forwardRef(
               </svg>
             </button>
           )}
-          {/* <button
+          <button
             onClick={handleToggle}
             aria-expanded={isVisible && !isMedium}
             aria-controls="navigation"
@@ -117,8 +114,8 @@ const PrimaryNav = forwardRef(
                   <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
                 </svg>
               )}
-            </Flex> */}
-          {/* </button> */}
+            </Flex>{' '}
+          </button>
         </Box>
         <Flex
           align="center"


### PR DESCRIPTION
# Describe your PR
Adjusting positioning on hero background image and made sure styles weren't overridden.

Fixes - Hero positioning bug in Chrome

## Pages/Interfaces that will change
Allies and Business Page hero panes

### Screenshots / video of changes
Before: 
Chrome
![image](https://user-images.githubusercontent.com/20157895/84225131-01d02c80-aaa4-11ea-91ac-9ba14d237d56.png)
![image](https://user-images.githubusercontent.com/20157895/84225301-6b503b00-aaa4-11ea-8357-180ab3668f5f.png)

Firefox
![image](https://user-images.githubusercontent.com/20157895/84225226-36dc7f00-aaa4-11ea-94cd-884025a42fbe.png)


After
![image](https://user-images.githubusercontent.com/20157895/84225181-1c0a0a80-aaa4-11ea-8c50-d5d7e23b611d.png)
![image](https://user-images.githubusercontent.com/20157895/84225279-6095a600-aaa4-11ea-99fc-cdbb05a01601.png)

## Steps to test

1. Go to Allies or Business Page
2. -> Profit