### PR TITLE
Keep ally buttons aligned. Update to unlist

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -81,7 +81,6 @@ const CardButtonGroup = forwardRef(({ children, ...props }, ref) => {
       spacing={3}
       // as={props => <Sta {...props} spacing={4} />}
       alignItems="center"
-      mt={3}
       width="100%"
       {...props}
       ref={ref}

--- a/src/components/Cards/AllyCard.js
+++ b/src/components/Cards/AllyCard.js
@@ -103,12 +103,12 @@ const AllyCard = forwardRef(
                 {specialty}
               </CardText>
             )}
-            <CardButtonGroup>
-              <CardButton as="a" href={`mailto:${email}`}>
-                Email
-              </CardButton>
-            </CardButtonGroup>
             <Box marginTop="auto" paddingTop={theme.spacing.base}>
+              <CardButtonGroup pb={3}>
+                <CardButton as="a" href={`mailto:${email}`}>
+                  Email
+                </CardButton>
+              </CardButtonGroup>
               <Text as="small" fontSize="sm" mt={3} isInline>
                 <Icon
                   name="flag"
@@ -130,7 +130,7 @@ const AllyCard = forwardRef(
                   onClick={onOpen}
                   ref={updateRef}
                 >
-                  update
+                  unlist
                 </Link>
               </Text>
             </Box>

--- a/src/components/Feeds/AllyFeed.js
+++ b/src/components/Feeds/AllyFeed.js
@@ -72,7 +72,7 @@ const AllyFeed = props => {
       paddingX={[null, theme.spacing.base, theme.spacing.lg]}
     >
       {allies.length > 0 ? (
-        <SimpleGrid columns={[null, 1, 2, 4]} spacing={theme.spacing.med}>
+        <SimpleGrid columns={[null, 1, 3, 4]} spacing={theme.spacing.med}>
           {allies.map((allies, index) => {
             if (index === 4)
               return (


### PR DESCRIPTION
# Describe your PR
- Keep ally buttons aligned in the same row regardless of user input content
- Reword 'Report or Update' to 'Report or Unlist'

Fixes # 81, 111

## Pages/Interfaces that will change
Ally Card

### Screenshots / video of changes

Before:
![image](https://user-images.githubusercontent.com/20157895/84227170-4b6f4600-aaa9-11ea-86b7-d18ad0cccebe.png)

After:
![image](https://user-images.githubusercontent.com/20157895/84227219-66da5100-aaa9-11ea-8c0e-fe97dd028596.png)


## Steps to test

1. Open Allies page
2. View row of cards where names take up different amount of rows
3. -> Buttons are still inline.
4. -> Text says Unlist instead of Update
