### PR TITLE
Render close icon when slideout menu is open

### DIFF
--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -55,21 +55,36 @@ const PrimaryNav = forwardRef(
             onClick={handleToggle}
             aria-expanded={isVisible && !isMedium}
             aria-controls="navigation"
+            outline="transparent"
           >
             <VisuallyHidden>
               {`${isVisible ? 'Hide' : 'Show'} the navigation menu`}
             </VisuallyHidden>
-            <svg
-              aria-hidden
-              width="30px"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-              fill={theme.colors['rbb-black-000']}
-            >
-              <title>Menu</title>
-
-              <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
-            </svg>
+            <Flex h="40px" w="40px" justify="center" align="center">
+              <svg
+                width="28"
+                height="27"
+                viewBox="0 0 28 27"
+                fill="#001514"
+                stroke="#001514"
+                stroke-width="2"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                {isVisible ? (
+                  <>
+                    <title>Close</title>
+                    <line x1="2.70711" y1="1.29289" x2="26.7487" y2="25.3345" />
+                    <line x1="1.29289" y1="25.2929" x2="25.3345" y2="1.25123" />
+                  </>
+                ) : (
+                  <>
+                    <title>Menu</title>
+                    <line y1="8" x2="34" y2="8" />
+                    <line y1="19" x2="34" y2="19" />
+                  </>
+                )}
+              </svg>
+            </Flex>
           </button>
         </Box>
         <Flex


### PR DESCRIPTION
# Describe your PR
Added a Close SVG and now conditionally render based on slideout menu state. Also changed the old menu icon to be what we had in design mocks.

Related to https://trello.com/c/KSmx0iZC/113-mobile-menu-needs-a-close-icon

## Pages/Interfaces that will change
Mobile Nav

### Screenshots / video of changes

Before:
![image](https://user-images.githubusercontent.com/20157895/84228608-1ebd2d80-aaad-11ea-89d9-406d55a89b2b.png)

![image](https://user-images.githubusercontent.com/20157895/84228628-28df2c00-aaad-11ea-88c0-68ccf7621050.png)


After:
![image](https://user-images.githubusercontent.com/20157895/84228587-0f3de480-aaad-11ea-94d8-34e58d2e6c81.png)

![image](https://user-images.githubusercontent.com/20157895/84228575-04834f80-aaad-11ea-9100-5ade83356f4d.png)



## Steps to test

1. Open Mobile Nav
2. -> See new Menu icon
3. Click Menu icon
4. -> See new Close icon

### Additional notes
