### PR TITLE
Fixing hero bg image alignment

### DIFF
--- a/src/components/PageHero.js
+++ b/src/components/PageHero.js
@@ -15,11 +15,13 @@ const PageHero = ({ title, subtitle, heroImageUrl, hasFadedHeroImage }) => {
           position="absolute"
           zIndex={-9}
           top={0}
+          left={0}
           width="100%"
           height="100vh"
           backgroundSize="cover"
           backgroundRepeat="no-repeat"
-          background={`${
+          backgroundPosition="top center"
+          backgroundImage={`${
             hasFadedHeroImage ? gradientFade : ''
           } url(${heroImageUrl})`}
         />


### PR DESCRIPTION
# Describe your PR
Adjusting positioning on hero background image and made sure styles weren't overridden.

Fixes - Hero positioning bug in Chrome

## Pages/Interfaces that will change
Allies and Business Page hero panes

### Screenshots / video of changes
Before: 
Chrome
![image](https://user-images.githubusercontent.com/20157895/84225131-01d02c80-aaa4-11ea-91ac-9ba14d237d56.png)
![image](https://user-images.githubusercontent.com/20157895/84225301-6b503b00-aaa4-11ea-8357-180ab3668f5f.png)

Firefox
![image](https://user-images.githubusercontent.com/20157895/84225226-36dc7f00-aaa4-11ea-94cd-884025a42fbe.png)


After
![image](https://user-images.githubusercontent.com/20157895/84225181-1c0a0a80-aaa4-11ea-8c50-d5d7e23b611d.png)
![image](https://user-images.githubusercontent.com/20157895/84225279-6095a600-aaa4-11ea-99fc-cdbb05a01601.png)

## Steps to test

1. Go to Allies or Business Page
2. -> Profit