### PR TITLE
Position absolute bg for about page

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -26,6 +26,8 @@ export default function About() {
             publicId="assets/people-protesting-on-street-4552840_gginry"
             cloudName="rebuild-black-business"
             pos="absolute"
+            top={0}
+            left={0}
             objectFit="cover"
             w="100%"
             h="100%"

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -26,7 +26,7 @@ export default function About() {
             publicId="assets/people-protesting-on-street-4552840_gginry"
             cloudName="rebuild-black-business"
             pos="absolute"
-            top={0}
+            top="-27%"
             left={0}
             objectFit="cover"
             w="100%"


### PR DESCRIPTION
# Describe your PR
Positions the image for Chrome

Fixes https://trello.com/c/Z37ZH9QB/115-about-background-off-center-on-chrome

## Pages/Interfaces that will change
About

### Screenshots / video of changes
Before:
![image](https://user-images.githubusercontent.com/20157895/84230763-537fb380-aab2-11ea-89b5-7e7cc710ce25.png)

After:
![image](https://user-images.githubusercontent.com/20157895/84230673-2af7b980-aab2-11ea-8cf2-41b50ebdadf0.png)

## Steps to test

1. Open About page in Chrome
2. See the image properly shown
