### PR TITLE
update to only add photography credits paragraph when there are credits

### DIFF
--- a/src/components/footer/PhotoCredits.js
+++ b/src/components/footer/PhotoCredits.js
@@ -14,27 +14,39 @@ const CreditLink = () => {
       <StaticQuery
         query={PhotoCreditsLinks}
         render={data => {
+          // We check the current pages pathname against the credits pathname to render the correct photographers for each page
+          const pagePhotoCreditLinks = data.site.siteMetadata.photoCreditLinks.filter(
+            link => link.pagePathname === location.pathname
+          );
           return (
             <Flex justify="center">
-              {data.site.siteMetadata.photoCreditLinks
-                .filter(link => link.pagePathname === location.pathname) // We check the current pages pathname against the credits pathname to render the correct photographers for each page
-                .map((link, index) => {
-                  return (
-                    <Link
-                      variant="footer"
-                      to={link.url}
-                      fontSize="12px"
-                      fontWeight="bold"
-                      ml="1"
-                      mr="1"
-                      color={theme.footer.photoCreditLink}
-                      isExternal
-                      key={index}
-                    >
-                      {link.photographer}
-                    </Link>
-                  );
-                })}
+              {pagePhotoCreditLinks.length > 0 && (
+                <Text
+                  fontSize="12px"
+                  fontFamily={theme.fonts.heading}
+                  color={theme.colors['rbb-white']}
+                  opacity={0.5}
+                >
+                  Photography credits:
+                </Text>
+              )}
+              {pagePhotoCreditLinks.map((link, index) => {
+                return (
+                  <Link
+                    variant="footer"
+                    to={link.url}
+                    fontSize="12px"
+                    fontWeight="bold"
+                    ml="1"
+                    mr="1"
+                    color={theme.footer.photoCreditLink}
+                    isExternal
+                    key={index}
+                  >
+                    {link.photographer}
+                  </Link>
+                );
+              })}
             </Flex>
           );
         }}
@@ -51,14 +63,6 @@ const PhotoCredit = () => {
         textAlign="center"
         direction={['column', 'column', 'column', 'row']}
       >
-        <Text
-          fontSize="12px"
-          fontFamily={theme.fonts.heading}
-          color={theme.colors['rbb-white']}
-          opacity={0.5}
-        >
-          Photography credits:
-        </Text>
         <CreditLink />
       </Flex>
     </Flex>


### PR DESCRIPTION
# Describe your PR
Updates to not display "Photography credits:" in the footer unless there are credits on the page.

Related to # https://github.com/Rebuild-Black-Business/RBB-Website/issues/126
Fixes #

## Pages/Interfaces that will change
footer on pages like /legal without photo credits.

### Screenshots / video of changes

`/`
<img width="557" alt="Screen Shot 2020-06-10 at 7 52 54 AM" src="https://user-images.githubusercontent.com/6998954/84264729-af1c6200-aaef-11ea-9491-57e70fa64b92.png">
`/legal`
<img width="579" alt="Screen Shot 2020-06-10 at 7 53 03 AM" src="https://user-images.githubusercontent.com/6998954/84264730-af1c6200-aaef-11ea-8835-98d402992600.png">


Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1.

### Additional notes
