### PR TITLE
fix: homepage img a11y fixes

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -4,7 +4,7 @@ import { Image as ChakraImage } from '@chakra-ui/core';
 import ImageSkeleton from './Loading/ImageSkeleton';
 
 export default function Image(props) {
-  const { transforms, publicId, alt, src, ...remainingProps } = props;
+  const { transforms, publicId, alt, src } = props;
 
   const { getImage, data, status, error } = useImage({
     cloud_name: 'rebuild-black-business',
@@ -29,7 +29,5 @@ export default function Image(props) {
   // @TODO :: Deliver custom Error UI if needed
   if (status === 'error') return <p>{error.message}</p>;
 
-  return (
-    <ChakraImage {...props} src={data || src} alt={alt} {...remainingProps} />
-  );
+  return <ChakraImage {...props} src={data || src} alt={alt} />;
 }


### PR DESCRIPTION
# Describe your PR

This fix adds a a `role="presentation"` to the images on the homepage since they are technically background images and don't provide any semantic meaning.
