### PR TITLE
addes hrefs to /ally for ally buttons

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,8 +3,8 @@ import {
   ButtonGroup,
   Flex,
   Heading,
-  Text,
   Link,
+  Text,
   useTheme,
 } from '@chakra-ui/core';
 import { graphql, StaticQuery } from 'gatsby';
@@ -125,7 +125,14 @@ export default () => {
               <Button variant="primary" maxW="230px;" m={3} h="auto" px="30px">
                 Add Business
               </Button>
-              <Button variant="secondary" m={3} h="auto" px="30px">
+              <Button
+                variant="secondary"
+                m={3}
+                h="auto"
+                px="30px"
+                as={Link}
+                href="/allies"
+              >
                 See Allies
               </Button>
             </ButtonGroup>
@@ -168,7 +175,14 @@ export default () => {
               <Button variant="primary" maxW="230px" m={3} h="auto" px="30px">
                 Add Business
               </Button>
-              <Button variant="secondary" m={3} h="auto" px="30px">
+              <Button
+                variant="secondary"
+                m={3}
+                h="auto"
+                px="30px"
+                as={Link}
+                href="/allies"
+              >
                 See Allies
               </Button>
             </ButtonGroup>


### PR DESCRIPTION
# Describe your PR

2 ally buttons on the homepage didnt have /ally redirects

Related to #
Fixes #

## Pages/Interfaces that will change
Home

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1. Go to home page
2. Click on 'See allies' button under 'BUSINESS OWNERS' heading
3. Click on 'See allies' button under HOW TO HELP' heading
4. Both should redirect to /allies

### Additional notes
