### PR TITLE
Fix pagination error on Allies page

### DIFF
--- a/src/components/Cards/AllyCard.js
+++ b/src/components/Cards/AllyCard.js
@@ -181,7 +181,8 @@ const AllyCard = forwardRef(
 AllyCard.displayName = 'AllyCard';
 AllyCard.propTypes = {
   specialty: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  first: PropTypes.string,
+  last: PropTypes.string,
   location: PropTypes.string,
   email: PropTypes.string.isRequired,
 };

--- a/src/components/Feeds/AllyFeed.js
+++ b/src/components/Feeds/AllyFeed.js
@@ -21,7 +21,6 @@ import NoResultsCard from '../Cards/NoResultsCard';
 import { CardWrapper, CardHeading, CardText, CardContent } from '../Card';
 import Button from '../Button';
 import Image from '../Image';
-import Pagination from '../Pagination/Pagination.jsx';
 import SubmitAlly from '../Forms/SubmitAlly';
 // @TODO :: Add proper content to this modal. Probably pull this out into its own file seeing as its going to be a form
 const ModalForm = ({ isOpen, onClose, title }) => (
@@ -186,7 +185,6 @@ const AllyFeed = props => {
           onClose={onClose}
         />
       </Box>
-      {allies.length > 0 && <Pagination totalRecords={70} pageLimit={5} />}
     </>
   );
 };

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -27,10 +27,6 @@ function Pagination({ location, currentPage, totalPages }) {
   const isWide = useMedia('(min-width: 480px)');
   const pageNeighbors = isWide ? 2 : 1;
 
-  // check to make sure pagination doesn't crash out pages that accidentally include it
-  if (!location) return null;
-  const pathname = location.pathname;
-
   /**
    * Let's say we have 10 pages and we set pageNeighbours to 2
    * Given that the current page is 6
@@ -83,6 +79,10 @@ function Pagination({ location, currentPage, totalPages }) {
 
     return range(1, totalPages);
   }, [currentPage, totalPages, pageNeighbors]);
+
+  // check to make sure pagination doesn't crash out pages that accidentally include it
+  if (!location) return null;
+  const pathname = location.pathname;
 
   /**
    * Create the correct page link

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -26,6 +26,9 @@ function Pagination({ location, currentPage, totalPages }) {
 
   const isWide = useMedia('(min-width: 480px)');
   const pageNeighbors = isWide ? 2 : 1;
+
+  // check to make sure pagination doesn't crash out pages that accidentally include it
+  if (!location) return null;
   const pathname = location.pathname;
 
   /**


### PR DESCRIPTION
# Describe your PR
This fixes an error on the allies page that was crashing out.  It was caused by a problem with Pagination, which is no longer included on the Allies page for V0

Related to #n/a
Fixes #n/a

## Pages/Interfaces that will change
/allies

### Screenshots / video of changes
It renders!
![image](https://user-images.githubusercontent.com/1844496/84329655-4666d100-ab53-11ea-9b28-0a1a2e2498dc.png)



Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1. pull up /allies on the deploy preview here

### Additional notes
