### PR TITLE
Try not to break when category is missing

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -18,11 +18,19 @@ import { toCamelCase } from '../utils/stringUtils';
 // TODO: Replace with real fallback images for each category.
 // This should all probably be defined in the database somewhere, eh?
 const categoryData = {
+  other: {
+    label: 'Other',
+    image: {
+      src: 'assets/rbb-socialimage_g7rhcj',
+      alt: 'Other',
+    },
+    buttonText: 'Learn More',
+  },
   entertainment: {
     label: 'Entertainment',
     image: {
       src: 'assets/business-entertainment-option',
-      alt: 'Id facilisis dictum consequat sit orci.',
+      alt: 'Entertainment business',
     },
     buttonText: 'Learn more',
   },
@@ -30,7 +38,7 @@ const categoryData = {
     label: 'Food and Beverage',
     image: {
       src: 'assets/business-food-beverage',
-      alt: 'Id facilisis dictum consequat sit orci.',
+      alt: 'Food and beverage business',
     },
     buttonText: 'Order',
   },
@@ -38,7 +46,7 @@ const categoryData = {
     label: 'Health and Wellness',
     image: {
       src: 'assets/business-health',
-      alt: 'Id facilisis dictum consequat sit orci.',
+      alt: 'Health and wellness business',
     },
     buttonText: 'Learn more',
   },
@@ -46,7 +54,7 @@ const categoryData = {
     label: 'Professional Services',
     image: {
       src: 'assets/business-services',
-      alt: 'Id facilisis dictum consequat sit orci.',
+      alt: 'Professional servicess business',
     },
     buttonText: 'Contact',
   },
@@ -54,7 +62,7 @@ const categoryData = {
     label: 'Retail',
     image: {
       src: 'assets/business-retail',
-      alt: 'Id facilisis dictum consequat sit orci.',
+      alt: 'Retail business',
     },
     buttonText: 'Shop',
   },
@@ -92,7 +100,7 @@ const ResultCard = forwardRef(
     },
     ref
   ) => {
-    const catVar = toCamelCase(category);
+    const catVar = toCamelCase(category || 'other');
     const hasFallbackImage =
       category && Object.keys(categoryData).includes(catVar);
     const hasImage = !!(imageSrc || hasFallbackImage);
@@ -117,9 +125,9 @@ const ResultCard = forwardRef(
       >
         {hasImage && (
           <CardImage
-            publicId={!imageSrc ? categoryData[catVar].image.src : null}
+            publicId={!imageSrc ? categoryData[catVar]?.image.src : null}
             src={imageSrc ? imageSrc : null}
-            alt={imageAlt || categoryData[catVar].image.alt}
+            alt={imageAlt || categoryData[catVar]?.image.alt}
           />
         )}
         <CardContent

--- a/src/utils/stringUtils.js
+++ b/src/utils/stringUtils.js
@@ -1,4 +1,5 @@
 export const toCamelCase = string => {
+  if (!string) return null;
   string = string
     .toLowerCase()
     .replace(/(?:(^.)|([-_\s]+.))/g, function (match) {


### PR DESCRIPTION
# Describe your PR
Business page is breaking when incomplete data finds its way there.  This is an attempt to mitigate that!

Related to n/a	
Fixes # n/a

## Pages/Interfaces that will change
/businesses

### Screenshots / video of changes
...hard to tell if this is working until the deploy preview lights up, I think?

## Steps to test

1. load /businesses and make sure the page doesn't crash!

### Additional notes
