### PR TITLE
Truncate description to 250 characters

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -2,6 +2,7 @@ import { Box, Heading, Icon, Text, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import React, { forwardRef } from 'react';
 import Link from '../components/Link';
+
 import { zipcodeConversion } from '../utils/locationUtils';
 import { toCamelCase } from '../utils/stringUtils';
 import {
@@ -12,9 +13,6 @@ import {
   CardText,
   CardWrapper,
 } from './Card';
-
-import { zipcodeConversion } from '../utils/locationUtils';
-import { toCamelCase } from '../utils/stringUtils';
 
 const DESCRIPTION_MAX_LENGTH = 250; // length in characters after which we'll trim descriptions
 

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -15,6 +15,8 @@ import {
 import { zipcodeConversion } from '../utils/locationUtils';
 import { toCamelCase } from '../utils/stringUtils';
 
+const DESCRIPTION_MAX_LENGTH = 250; // length in characters after which we'll trim descriptions
+
 // TODO: Replace with real fallback images for each category.
 // This should all probably be defined in the database somewhere, eh?
 const categoryData = {
@@ -142,7 +144,12 @@ const ResultCard = forwardRef(
               {categoryLabel}
             </CardText>
           )}
-          {description && <CardText as="p">{description}</CardText>}
+          {description && (
+            <CardText as="p">
+              {description.substr(0, DESCRIPTION_MAX_LENGTH)}
+              {description.length > DESCRIPTION_MAX_LENGTH && '…'}{' '}
+            </CardText>
+          )}
           {formattedCity && <CardText as="p">{formattedCity}</CardText>}
           <CardButtonGroup mt={theme.spacing.base} mb={theme.spacing.base}>
             <CardButton


### PR DESCRIPTION
# Describe your PR

Fixes https://trello.com/c/Auq603FR/161-business-result-card-blurb-should-be-cut-off-at-100-char

The trello card called for 100characters, but that ends up being very short.  I'm suggesting 250 instead.



## Pages/Interfaces that will change

### Screenshots / video of changes
100 char
![image](https://user-images.githubusercontent.com/1844496/84332587-4b2f8300-ab5b-11ea-986f-0c232146c44c.png)


250 char
![image](https://user-images.githubusercontent.com/1844496/84332597-51bdfa80-ab5b-11ea-9418-2dfa31eef780.png)


## Steps to test

1. check out `/businesses` - there shouldn't be any _crazy long_ entries any longer!

### Additional notes
Eventually this should be extended by providing a modal that shows the entire card with description if the length is longer than the cutoff