### PR TITLE
fix ally button links being backwards and point to ally form not busi…

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -225,8 +225,8 @@ export default () => {
                 m={3}
                 h="auto"
                 px="30px"
-                onClose={onClose}
-                onClick={() => handleType('business')}
+                as={Link}
+                href="/allies"
               >
                 View Directory
               </Button>
@@ -235,8 +235,8 @@ export default () => {
                 m={3}
                 h="auto"
                 px="30px"
-                as={Link}
-                href="/allies"
+                onClose={onClose}
+                onClick={() => handleType('ally')}
               >
                 Sign up as an Ally
               </Button>


### PR DESCRIPTION
# Describe your PR
Ally button links were backwards on home page and linked to business form

## Steps to test

1. Click both links
