### PR TITLE
Open consistent modal for reporting or unlisting a Business and Ally 

### DIFF
--- a/src/components/Cards/AllyCard.js
+++ b/src/components/Cards/AllyCard.js
@@ -1,22 +1,7 @@
-import {
-  Box,
-  Icon,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Text,
-  useDisclosure,
-  useTheme,
-} from '@chakra-ui/core';
-import { graphql, StaticQuery } from 'gatsby';
+import { Box, Icon, Text, useDisclosure, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import React, { forwardRef, useRef } from 'react';
 import { zipcodeConversion } from '../../utils/locationUtils';
-import Button from '../Button';
 import {
   CardButton,
   CardButtonGroup,
@@ -25,53 +10,8 @@ import {
   CardText,
   CardWrapper,
 } from '../Card';
-import ErrorBoundary from '../ErrorBoundary';
 import Link from '../Link';
-
-// @TODO :: Add proper content to this modal. Probably pull this out into its own file seeing as its going to be a form
-const ModalForm = ({ isOpen, onClose, title }) => (
-  <Modal isOpen={isOpen} onClose={onClose}>
-    <ModalOverlay />
-    <ModalContent>
-      <ModalHeader maxWidth="97%">{title}</ModalHeader>
-      <ModalCloseButton />
-      <ErrorBoundary>
-        <StaticQuery
-          query={ContactQuery}
-          render={data => (
-            <ModalBody>
-              Please send an email to{' '}
-              <Link
-                variant="standard"
-                href={`mailto:${data.site.siteMetadata.social.contact}`}
-              >
-                {data.site.siteMetadata.social.contact}
-              </Link>{' '}
-              to report or remove this listing.
-            </ModalBody>
-          )}
-        />
-      </ErrorBoundary>
-      <ModalFooter>
-        <Button variantColor="blue" m={3} onClick={onClose}>
-          Close
-        </Button>
-      </ModalFooter>
-    </ModalContent>
-  </Modal>
-);
-
-const ContactQuery = graphql`
-  query ReportRemoveContactQuery {
-    site {
-      siteMetadata {
-        social {
-          contact
-        }
-      }
-    }
-  }
-`;
+import ContactModal from '../ContactModal';
 
 /**
  * @component
@@ -159,7 +99,7 @@ const AllyCard = forwardRef(
           </CardContent>
         </CardWrapper>
 
-        <ModalForm
+        <ContactModal
           isOpen={isOpen}
           title={`Report or Update the listing for "${name}"`}
           onClose={onClose}

--- a/src/components/Cards/AllyCard.js
+++ b/src/components/Cards/AllyCard.js
@@ -88,7 +88,7 @@ const ContactQuery = graphql`
 const AllyCard = forwardRef(
   ({ first, last, email, specialty, location, ...props }, ref) => {
     const { onOpen, isOpen, onClose } = useDisclosure();
-    const { reportRef, updateRef } = useRef();
+    const { updateRef } = useRef();
     const theme = useTheme();
 
     const name = `${first} ${last}`;
@@ -150,18 +150,9 @@ const AllyCard = forwardRef(
                   as="button"
                   variant="cta"
                   onClick={onOpen}
-                  ref={reportRef}
-                >
-                  Report
-                </Link>{' '}
-                or{' '}
-                <Link
-                  as="button"
-                  variant="cta"
-                  onClick={onOpen}
                   ref={updateRef}
                 >
-                  unlist
+                  Report or update
                 </Link>
               </Text>
             </Box>

--- a/src/components/ContactModal.js
+++ b/src/components/ContactModal.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/core';
+import { graphql, StaticQuery } from 'gatsby';
+import ErrorBoundary from './ErrorBoundary';
+import Button from './Button';
+import Link from './Link';
+
+const ContactModal = ({ isOpen, onClose, title }) => (
+  <Modal isOpen={isOpen} onClose={onClose}>
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader maxWidth="97%">{title}</ModalHeader>
+      <ModalCloseButton />
+      <ErrorBoundary>
+        <StaticQuery
+          query={ContactQuery}
+          render={data => (
+            <ModalBody>
+              Please send an email to{' '}
+              <Link
+                variant="standard"
+                href={`mailto:${data.site.siteMetadata.social.contact}`}
+              >
+                {data.site.siteMetadata.social.contact}
+              </Link>{' '}
+              to report or remove this listing.
+            </ModalBody>
+          )}
+        />
+      </ErrorBoundary>
+      <ModalFooter>
+        <Button variantColor="blue" m={3} onClick={onClose}>
+          Close
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+);
+
+ContactModal.propTypes = {
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+const ContactQuery = graphql`
+  query ReportRemoveContactQuery {
+    site {
+      siteMetadata {
+        social {
+          contact
+        }
+      }
+    }
+  }
+`;
+
+export default ContactModal;

--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -26,7 +26,7 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
             return (
               <ResultCard
                 key={business.objectID}
-                name={business.business_name}
+                name={business.name}
                 category={business.category}
                 description={business.business_description}
                 location={business.zip_code}

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -1,4 +1,11 @@
-import { Box, Heading, Icon, Text, useTheme } from '@chakra-ui/core';
+import {
+  Box,
+  Heading,
+  Icon,
+  Text,
+  useTheme,
+  useDisclosure,
+} from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import React, { forwardRef } from 'react';
 import Link from '../components/Link';
@@ -12,6 +19,7 @@ import {
   CardText,
   CardWrapper,
 } from './Card';
+import ContactModal from '../components/ContactModal';
 
 const DESCRIPTION_MAX_LENGTH = 250; // length in characters after which we'll trim descriptions
 
@@ -105,6 +113,7 @@ const ResultCard = forwardRef(
       category && Object.keys(categoryData).includes(catVar);
     const hasImage = !!(imageSrc || hasFallbackImage);
     const theme = useTheme();
+    const { onOpen, isOpen, onClose } = useDisclosure();
 
     // I'm not sure how categories are going to work, so this probaably needs to
     // change. Also unsure how we're going to handle the schema category on the
@@ -181,12 +190,18 @@ const ResultCard = forwardRef(
                 color={theme.colors['rbb-gray']}
                 mr={theme.spacing.xs}
               />
-              <Link variant="cta" href="mailto:">
+              <Link as="button" variant="cta" onClick={onOpen}>
                 Report or update
               </Link>
             </Text>
           </Box>
         </CardContent>
+
+        <ContactModal
+          isOpen={isOpen}
+          title={`Report or Update the listing for "${name}"`}
+          onClose={onClose}
+        />
       </CardWrapper>
     );
   }


### PR DESCRIPTION
This updates the business feed "report or unlist" links to open a modal with contact steps to take action on a business listing. This also refines the "update or unlist" link for allies page to be consistent with businesses feed items. 

## Pages/Interfaces that will change

- Extracts contact modal from AllyCard into centralized component
- Uses ContactModal component on BusinessFeed and is opened when the "report or unlist" link is clicked for a business
- Fixes business name prop in each feed item

### Screenshots / video of changes

Example Business modal:
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/235503/84344685-4ae5b680-ab60-11ea-809e-f50ee1dbadc3.png">

Example Ally modal:
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/235503/84344699-5507b500-ab60-11ea-83b6-bbff34d522ff.png">
