### PR TITLE
Wrap business feed rendering in loading state effect

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -1,37 +1,44 @@
 import { Box, SimpleGrid, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import NoResultsCard from '../Cards/NoResultsCard';
 import BusinessFilter from '../Filters/BusinessFilter';
 import ResultCard from '../ResultCard';
 
 function BusinessFeed({ businesses, onSearch, selectedFilters }) {
   const theme = useTheme();
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
 
   return (
     <Box
       maxW={theme.containers.main}
       paddingX={[null, theme.spacing.base, theme.spacing.lg]}
     >
-      <BusinessFilter
-        onSearch={filters => onSearch(filters)}
-        selectedFilters={selectedFilters}
-      />
-      {businesses.length > 0 ? (
-        <SimpleGrid columns={[null, 1, 2]} spacing={10}>
-          {businesses.map(business => {
-            return (
-              <ResultCard
-                key={business.objectID}
-                name={business.name}
-                category={business.category}
-                description={business.business_description}
-                location={business.zip_code}
-                websiteUrl={business.website}
-              />
-            );
-          })}
-        </SimpleGrid>
+      {loaded && businesses.length > 0 ? (
+        <>
+          <BusinessFilter
+            onSearch={filters => onSearch(filters)}
+            selectedFilters={selectedFilters}
+          />
+          <SimpleGrid columns={[null, 1, 2]} spacing={10}>
+            {businesses.map(business => {
+              return (
+                <ResultCard
+                  key={business.objectID}
+                  name={business.name}
+                  category={business.category}
+                  description={business.business_description}
+                  location={business.zip_code}
+                  websiteUrl={business.website}
+                />
+              );
+            })}
+          </SimpleGrid>
+        </>
       ) : (
         <NoResultsCard type="businesses" />
       )}


### PR DESCRIPTION
Fixes some bad layout bugs with business feed loading state not guarding against a component render. Relates to #135
## Pages/Interfaces that will change

/businesses

### Screenshots / video of changes

Previously this would load a 404 page initially on page load then inject the business feed after-the-fact causing layout bugs: 
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/235503/84348128-10344c00-ab69-11ea-90f6-b92bd043e0a5.png">

This now renders the business feed correctly on page load: 
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/235503/84348191-34902880-ab69-11ea-8ad4-7f6ea752ebfc.png">
