### PR TITLE
Temporarily remove scroll-lock while nav slideout is open

### DIFF
--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -29,7 +29,8 @@ const PrimaryNav = forwardRef(
     const toUpperCase = text => text.toUpperCase();
     const { isOpen, onOpen, onClose } = useDisclosure();
     const handleToggle = () => {
-      document.body.style.position = isVisible ? 'unset' : 'fixed';
+      // TODO: Prevent scrolling while the slideout is open. The below logic works, but if a user clicks a link they'll keep the fixed position
+      // document.body.style.position = isVisible ? 'unset' : 'fixed';
       setIsVisible(!isVisible);
     };
 


### PR DESCRIPTION
# Describe your PR
Removed scroll-lock while nav slideout is open

Fixes the problem where users couldn't scroll after using the mobile nav

## Pages/Interfaces that will change
Mobile Nav Navigation

## Steps to test

1. Open Mobile Nav
2. Click a link
3. -> Scroll

1. Open Mobile Nav on Allies page
2. Scroll with slideout open
3. -> Cry