### PR TITLE
Enable `gatsby-plugin-netlify`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -201,5 +201,6 @@ module.exports = {
       },
     },
     'gatsby-plugin-sitemap',
+    'gatsby-plugin-netlify',
   ],
 };


### PR DESCRIPTION
This is to try and get client routes for business types working on Netlify. Currently they show a 404 and then the business feed comes into view afterwards.

According to [the docs](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#configuration) on the plugin, this should enable:

> Redirect rules are automatically added for client only paths.

