### PR TITLE
fixed photo credits layout on mobile. Ran prettier

### DIFF
--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -58,7 +58,7 @@ const PrimaryNav = forwardRef(
         <Nav
           zIndex={1}
           position="absolute"
-          width="100vw"
+          width="100%"
           height={NAV_HEIGHT}
           ref={ref}
           align="center"

--- a/src/components/footer/PhotoCredits.js
+++ b/src/components/footer/PhotoCredits.js
@@ -19,7 +19,10 @@ const CreditLink = () => {
             link => link.pagePathname === location.pathname
           );
           return (
-            <Flex justify="center">
+            <Flex
+              justify="center"
+              direction={['column', 'column', 'column', 'row']}
+            >
               {pagePhotoCreditLinks.length > 0 && (
                 <Text
                   fontSize="12px"


### PR DESCRIPTION
This PR fixes the photo credits layout on mobile view. Ran prettier which hasnt been done for a while so affected alot of files

## Pages/Interfaces that will change

### Screenshots / video of changes

![CREDIT-FIX](https://user-images.githubusercontent.com/22930449/84354527-51584a80-abc1-11ea-96e3-7085a63f2a3e.PNG)


## Steps to test

Local dev, check mobile viewon dev tools

### Additional notes
