### PR TITLE
fix: PrimaryButton colors for various states

### DIFF
--- a/src/components/Buttons/PrimaryButton.js
+++ b/src/components/Buttons/PrimaryButton.js
@@ -7,8 +7,8 @@ function PrimaryButton(props) {
   return (
     <Button
       {...props}
-      bg={theme.buttons.primary.backgroundColor}
-      color={theme.buttons.primary.color}
+      bg={theme.buttons.primary.backgroundColor.default}
+      color={theme.buttons.primary.color.default}
       borderRadius="button"
       border="primaryButton"
       borderWidth="button"
@@ -20,18 +20,18 @@ function PrimaryButton(props) {
       padding={theme.buttons.primary.padding}
       textTransform={theme.buttons.primary.textTransform}
       _active={{
-        bg: theme.buttons.primary.activeBackgroundColor,
-        borderColor: theme.buttons.primary.activeColor,
-        color: theme.buttons.primary.activeColor,
+        bg: theme.buttons.primary.backgroundColor.active,
+        borderColor: theme.buttons.primary.borderColor.active,
+        color: theme.buttons.primary.color.active,
       }}
       _disabled={{
-        color: theme.buttons.primary.disabledColor,
+        color: theme.buttons.primary.color.disabled,
       }}
       _focus={{
-        bg: theme.buttons.primary.hoverBackgroundColor,
+        bg: theme.buttons.primary.backgroundColor.focus,
       }}
       _hover={{
-        bg: theme.buttons.primary.hoverBackgroundColor,
+        bg: theme.buttons.primary.backgroundColor.hover,
       }}
     >
       {props.children}


### PR DESCRIPTION
# Describe your PR
The PrimaryButton component had multiple color attributes pointing to the wrong property inside the theme.

## Pages/Interfaces that will change
- PrimaryButton

### Screenshots / video of changes
Before:
![image](https://user-images.githubusercontent.com/1674958/84356209-7f219d00-ab89-11ea-910c-6f31d9e328d4.png)
Before Hover:
![image](https://user-images.githubusercontent.com/1674958/84356367-b2fcc280-ab89-11ea-9971-616078652921.png)

After:
![image](https://user-images.githubusercontent.com/1674958/84356263-906aa980-ab89-11ea-9de3-e28dded5398b.png)
After Hover:
![image](https://user-images.githubusercontent.com/1674958/84356485-de7fad00-ab89-11ea-92a8-96578a5ac9b1.png)


## Steps to test

1. Load up /allies page and interact with the buttons