### PR TITLE
fix: spacing on ResultCard

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -140,6 +140,8 @@ const ResultCard = forwardRef(
           />
         )}
         <CardContent
+          d="flex"
+          flexDirection="column"
           bg={theme.colors['rbb-result-card-grey']}
           color={hasImage ? undefined : theme.colors['rbb-black-200']}
         >
@@ -162,7 +164,11 @@ const ResultCard = forwardRef(
             </CardText>
           )}
           {formattedCity && <CardText as="p">{formattedCity}</CardText>}
-          <CardButtonGroup mt={theme.spacing.base} mb={theme.spacing.base}>
+          <CardButtonGroup
+            mt="auto"
+            mb={theme.spacing.base}
+            pt={theme.spacing.base}
+          >
             {websiteUrl && (
               <CardButton
                 as="a"


### PR DESCRIPTION
# Describe your PR
This pushes the "Report or update" links to the bottom of the card, rather than floating in certain cases.

## Pages/Interfaces that will change
- ResultCard
- /business

### Screenshots / video of changes
Before:
![Screen Shot 2020-06-11 at 3 02 35 AM](https://user-images.githubusercontent.com/1674958/84360994-9d3ecb80-ab90-11ea-9c33-e659f92002da.png)

After:
![Screen Shot 2020-06-11 at 3 02 47 AM](https://user-images.githubusercontent.com/1674958/84361004-a2037f80-ab90-11ea-8bc7-408e88d1f683.png)

## Steps to test

1. Load up /business page