### PR TITLE
pull in business_name as default name for business card + have fallback

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -26,10 +26,11 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
           />
           <SimpleGrid columns={[null, 1, 2]} spacing={10}>
             {businesses.map(business => {
+              console.log('HEY', business);
               return (
                 <ResultCard
                   key={business.objectID}
-                  name={business.name}
+                  name={business.business_name || business.name}
                   category={business.category}
                   description={business.business_description}
                   location={business.zip_code}

--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -26,7 +26,6 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
           />
           <SimpleGrid columns={[null, 1, 2]} spacing={10}>
             {businesses.map(business => {
-              console.log('HEY', business);
               return (
                 <ResultCard
                   key={business.objectID}


### PR DESCRIPTION
# Describe your PR

Related to # https://github.com/Rebuild-Black-Business/RBB-Website/issues/194
Fixes #
This will display the name on a card as the business name and default to name if business name is unavailable. This should resolve the issue with missing business names in the BusinessCards.

## Pages/Interfaces that will change
/business search results 

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

Before:
<img width="1324" alt="Screen Shot 2020-06-11 at 7 11 55 AM" src="https://user-images.githubusercontent.com/6998954/84378918-ebfd5d00-abb2-11ea-8c5b-8043a533235b.png">


After:
<img width="1330" alt="Screen Shot 2020-06-11 at 7 12 14 AM" src="https://user-images.githubusercontent.com/6998954/84378916-eb64c680-abb2-11ea-9855-7145c8aa835d.png">


## Steps to test 

1. Visit /businesses/all
2. See business names appear 🎉 
