### PR TITLE
Swap Google Tag Manager for Google Analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,13 +175,14 @@ module.exports = {
       },
     },
     {
-      resolve: 'gatsby-plugin-google-tagmanager',
+      resolve: `gatsby-plugin-google-analytics`,
       options: {
-        id: process.env.GOOGLE_TAGMANAGER_ID, // pulls in from your .env file
-
-        // Include GTM in development.
-        // Defaults to false meaning GTM will only be loaded in production.
-        includeInDevelopment: false,
+        // The property ID; the tracking code won't be generated without it
+        trackingId: process.env.GOOGLE_ANALYTICS_PROPERTY_ID,
+        // Defines where to place the tracking script - `true` in the head and `false` in the body
+        head: false,
+        // Defers execution of google analytics script after page load
+        defer: false,
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10610,12 +10610,13 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-facebook-pixel/-/gatsby-plugin-facebook-pixel-1.0.3.tgz",
       "integrity": "sha512-IM4e+5FkpLUCV/69tU+GFXVAs0EJXBfM/BARO/6SaMqalLfj1fj4ZXUyC8kHy3RiTMuw+y8g2mdkBMZqj7RyWQ=="
     },
-    "gatsby-plugin-google-tagmanager": {
+    "gatsby-plugin-google-analytics": {
       "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.4.tgz",
-      "integrity": "sha512-81WLvTQUOJSAlXZZ8Aqz5Cw36w0y2BsHJjWc5VKC83W8NMXoE6nx1SY/iOKNjWWLoW43QlVlsYU/CFqEPbMySA==",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.4.tgz",
+      "integrity": "sha512-FjsHyZ1J+pxXqupG7SpCBIvxHVPWND2mYA4eK6c2i4B2d+6n60pPJd/YOqQdsxoIGLL210UOCnJpa6A7Vrd8pQ==",
       "requires": {
-        "@babel/runtime": "^7.10.2"
+        "@babel/runtime": "^7.10.2",
+        "minimatch": "3.0.4"
       }
     },
     "gatsby-plugin-manifest": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gatsby-plugin-chakra-ui": "^0.1.4",
     "gatsby-plugin-create-client-paths": "^2.3.4",
     "gatsby-plugin-facebook-pixel": "^1.0.3",
-    "gatsby-plugin-google-tagmanager": "^2.3.4",
+    "gatsby-plugin-google-analytics": "^2.3.4",
     "gatsby-plugin-manifest": "^2.4.11",
     "gatsby-plugin-netlify": "^2.3.4",
     "gatsby-plugin-react-helmet": "^3.3.3",


### PR DESCRIPTION
# Describe your PR
Removes the plugin for google tagmanager and includes one for google analytics instead. We may choose to swap back at some point, but for now this is simpler.

**Note:** this requires changing an environment variable - it used to be called `GOOGLE_TAGMANAGER_ID` and is now `GOOGLE_ANALYTICS_PROPERTY_ID`.  It should have the same value (`UA-somethingsomething`), but there's an important difference between the two ID types, which I didn't want to confuse.

## Steps to test

1. update that environment variable, then redeploy this branch and check google analytics for live activity

### Additional notes
