### PR TITLE
custom link component. custom btn component. back home link. removed escape from modal

### DIFF
--- a/src/pages/allies.js
+++ b/src/pages/allies.js
@@ -1,22 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { useLocalStorage } from 'react-use';
-
 import {
-  Text,
-  Button,
+  Box,
   Flex,
-  Link,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
   useDisclosure,
   useTheme,
 } from '@chakra-ui/core';
-
-import { AllyFeed, AllyFilter, PageHero, Image, Layout } from '../components';
+import React, { useEffect, useState } from 'react';
+import { useLocalStorage } from 'react-use';
+import { AllyFeed, AllyFilter, Image, Layout, PageHero } from '../components';
+import Button from '../components/Button';
+import Link from '../components/Link';
 
 export default function Allies(props) {
   const [allyFilters, setAllyFilters] = useState({
@@ -66,6 +65,7 @@ export default function Allies(props) {
             <Modal
               isOpen={isOpen}
               onClose={onClose}
+              closeOnEsc={false}
               size="lg"
               closeOnOverlayClick={false}
             >
@@ -78,26 +78,32 @@ export default function Allies(props) {
                   />
                 </ModalHeader>
                 <ModalBody fontSize="lg" mt="8">
-                  Please read and accept our{' '}
-                  <Link href="/legal#terms" color="rbb-orange" target="_blank">
+                  Please read and agree to our{' '}
+                  <Link variant="cta" href="/legal#terms">
                     terms and conditions
                   </Link>{' '}
                   to access our Ally list and contacts.
                 </ModalBody>
-
                 <ModalFooter>
                   <Button
                     margin="0 auto"
-                    variantColor="orange"
+                    variant="primary"
                     rightIcon="check"
                     onClick={() => {
                       setAcceptedTAC(true);
                       onClose();
                     }}
                   >
-                    I accept the Terms and Conditions
+                    I agree
                   </Button>
                 </ModalFooter>
+
+                <Box textAlign="center" marginBottom="0.625rem">
+                  or, {''}
+                  <Link variant="cta" href="/">
+                    back to the homepage
+                  </Link>
+                </Box>
               </ModalContent>
             </Modal>
           </>


### PR DESCRIPTION
# Describe your PR
custom link component. custom btn component. back home link. removed escape from modal

Related to #
Fixes #

## Pages/Interfaces that will change
/allies modal for T&C

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

Before
![image](https://user-images.githubusercontent.com/8475305/84405918-cd10c200-abd6-11ea-8f72-3767857d780d.png)

After
![image](https://user-images.githubusercontent.com/8475305/84405969-e154bf00-abd6-11ea-8d8f-2850a828febc.png)


## Steps to test

1. Make sure your localstorage is cleared
2. navigate to /ally
3. verify modal is using CTA button with "I agree" now
4. verify that you can't escape from the modal in any way
5. verify that there is now a link to go back home with cta link styling
6. verify that the link goes back home when clicked

### Additional notes
