### PR TITLE
make about page heading consistent with PageHeading

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -12,6 +12,7 @@ import {
   MISSION_MESSAGE,
   WHO_WE_ARE_MESSAGE,
 } from '../constants/about';
+import PageHeading from '../components/headings/PageHeading';
 
 export default function About() {
   const theme = useTheme();
@@ -28,13 +29,7 @@ export default function About() {
           color="#FFF"
           position="relative"
         >
-          <Heading
-            fontFamily={theme.fonts['heading-slab']}
-            size="xl"
-            textTransform="uppercase"
-          >
-            About
-          </Heading>
+          <PageHeading>About</PageHeading>
           <Image
             publicId="assets/people-protesting-on-street-4552840_gginry"
             cloudName="rebuild-black-business"

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -12,7 +12,7 @@ import {
   MISSION_MESSAGE,
   WHO_WE_ARE_MESSAGE,
 } from '../constants/about';
-import PageHeading from '../components/headings/PageHeading';
+import PageHeading from '../components/Headings/PageHeading';
 
 export default function About() {
   const theme = useTheme();


### PR DESCRIPTION
# Describe your PR
About page - Hero text ("ABOUT") is smaller size (2.25em) then on Businesses or Allies pages (3em)
- Update about page to use PageHeading component to ensure it's consistent with other PageHeadings.

Related to # https://trello.com/c/8OFHDDWW/211-about-page-hero-text-about-is-smaller-size-225em-then-on-bussinesses-or-allies-pages-3em
Fixes #

## Pages/Interfaces that will change
/about

### Screenshots / video of changes
Before:
<img width="1238" alt="Screen Shot 2020-06-11 at 6 25 10 PM" src="https://user-images.githubusercontent.com/6998954/84444975-f2babd00-ac10-11ea-8b7e-615ece32b24a.png">
After:
<img width="1242" alt="Screen Shot 2020-06-11 at 6 24 54 PM" src="https://user-images.githubusercontent.com/6998954/84444976-f3535380-ac10-11ea-8d8b-4c8ffb2d8cda.png">


Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1. Go to /about and /businesses and /allies and see that all of the page headings have the same style.

### Additional notes
