### PR TITLE
make ally button width consistent with other buttons on page 

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -228,6 +228,7 @@ export default () => {
               </Button>
               <Button
                 variant="secondary"
+                maxW="230px"
                 m={3}
                 h="auto"
                 px="30px"


### PR DESCRIPTION
# Describe your PR
Fixes: "Sign up as an ally" button is larger than all the other buttons on the page even though they should all be the same width. 

Related to # 
Fixes # https://trello.com/c/OYYtH3zR/217-sign-up-as-an-ally-button-inconsistent-width

## Pages/Interfaces that will change
`/` in How to help section


### Screenshots / video of changes

Before

<img width="1679" alt="Screen Shot 2020-06-11 at 8 31 51 PM" src="https://user-images.githubusercontent.com/6998954/84452094-da539e00-ac22-11ea-8a15-60b2200e6e46.png">
<img width="450" alt="Screen Shot 2020-06-11 at 8 32 03 PM" src="https://user-images.githubusercontent.com/6998954/84452095-daec3480-ac22-11ea-9a1c-c9a411a0ef47.png">
After
<img width="1680" alt="Screen Shot 2020-06-11 at 8 31 46 PM" src="https://user-images.githubusercontent.com/6998954/84452092-da539e00-ac22-11ea-90eb-b920f6e28727.png">

<img width="452" alt="Screen Shot 2020-06-11 at 8 32 12 PM" src="https://user-images.githubusercontent.com/6998954/84452096-daec3480-ac22-11ea-951f-23288ab6a4bd.png">



## Steps to test

1. Go to homepage
2. Scroll to how to help section
3. See that CTA buttons are consistent width

### Additional notes
