### PR TITLE
use ExternalLink component for external links

### DIFF
--- a/src/components/ContactModal.js
+++ b/src/components/ContactModal.js
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/core';
 import { graphql, StaticQuery } from 'gatsby';
 import ErrorBoundary from './ErrorBoundary';
-import Link from './Link';
+import ExternalLink from './ExternalLink';
 
 const ContactModal = ({ isOpen, onClose, title }) => (
   <Modal isOpen={isOpen} onClose={onClose}>
@@ -24,12 +24,12 @@ const ContactModal = ({ isOpen, onClose, title }) => (
           render={data => (
             <ModalBody>
               Please send an email to{' '}
-              <Link
+              <ExternalLink
                 variant="standard"
                 href={`mailto:${data.site.siteMetadata.social.contact}`}
               >
                 {data.site.siteMetadata.social.contact}
-              </Link>{' '}
+              </ExternalLink>{' '}
               to report or remove this listing.
             </ModalBody>
           )}

--- a/src/components/ExternalLink.js
+++ b/src/components/ExternalLink.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link as ChakraLink, useTheme } from '@chakra-ui/core';
+
+import { getLinkStyles } from './Link';
+
+function ExternalLink(props) {
+  const theme = useTheme();
+
+  if (!['standard', 'cta', 'footer'].includes(props.variant))
+    throw new Error(`Invalid <Link> variant: "${props.variant}"`);
+
+  const linkStyles = getLinkStyles(theme, props.variant);
+
+  return (
+    <ChakraLink {...linkStyles} {...props}>
+      {props.children}
+    </ChakraLink>
+  );
+}
+
+ExternalLink.displayName = 'Link';
+ExternalLink.propTypes = {
+  variant: PropTypes.oneOf(['standard', 'cta', 'footer']),
+};
+
+export default ExternalLink;

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link as ChakraLink, useTheme } from '@chakra-ui/core';
 import { Link as GatsbyLink } from 'gatsby';
 
-function getLinkStyles(theme, variant) {
+export function getLinkStyles(theme, variant) {
   const linkOpacityStates = theme.links[variant].opacity || {};
   return {
     fontFamily: theme.links.font,

--- a/src/components/footer/PhotoCredits.js
+++ b/src/components/footer/PhotoCredits.js
@@ -3,7 +3,7 @@ import { StaticQuery, graphql } from 'gatsby';
 import ErrorBoundary from './../ErrorBoundary';
 import { Flex, useTheme, Text } from '@chakra-ui/core';
 import { useLocation } from '@reach/router';
-import Link from '../Link';
+import ExternalLink from '../ExternalLink';
 
 const CreditLink = () => {
   const theme = useTheme();
@@ -35,9 +35,9 @@ const CreditLink = () => {
               )}
               {pagePhotoCreditLinks.map((link, index) => {
                 return (
-                  <Link
+                  <ExternalLink
                     variant="footer"
-                    to={link.url}
+                    href={link.url}
                     fontSize="12px"
                     fontWeight="bold"
                     ml="1"
@@ -47,7 +47,7 @@ const CreditLink = () => {
                     key={index}
                   >
                     {link.photographer}
-                  </Link>
+                  </ExternalLink>
                 );
               })}
             </Flex>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,6 +5,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import Image from '../components/Image';
 import Layout from '../components/Layout';
 import Link from '../components/Link';
+import ExternalLink from '../components/ExternalLink';
 
 export default function NotFound() {
   const theme = useTheme();
@@ -50,12 +51,12 @@ export default function NotFound() {
                   lineHeight="30px"
                 >
                   If this problem continues,{' '}
-                  <Link
+                  <ExternalLink
                     variant="cta"
                     href={`mailto:${data.site.siteMetadata.social.bugs}`}
                   >
                     please let us know.
-                  </Link>
+                  </ExternalLink>
                 </Text>
                 <br />
                 <Text
@@ -82,22 +83,22 @@ export default function NotFound() {
                   </ListItem>
 
                   <ListItem>
-                    <Link
+                    <ExternalLink
                       variant="standard"
                       to="http://join.rebuildblackbusiness.com/"
                       color="#000"
                     >
                       Volunteer with us
-                    </Link>
+                    </ExternalLink>
                   </ListItem>
                   <ListItem>
-                    <Link
+                    <ExternalLink
                       href={`mailto:${data.site.siteMetadata.social.contact}`}
                       variant="standard"
                       color="#000"
                     >
                       Contact us
-                    </Link>
+                    </ExternalLink>
                   </ListItem>
                 </List>
               </Flex>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -6,7 +6,8 @@ import Content from '../components/about/Content';
 import ErrorBoundary from '../components/ErrorBoundary';
 import Image from '../components/Image';
 import Layout from '../components/Layout';
-import Link from '../components/Link';
+import ExternalLink from '../components/ExternalLink';
+
 import {
   FOUNDER_MESSAGE,
   MISSION_MESSAGE,
@@ -76,41 +77,41 @@ export default function About() {
               message={
                 <>
                   When I started {''}
-                  <Link variant="cta" href="https://www.renderatl.com/">
+                  <ExternalLink variant="cta" href="https://www.renderatl.com/">
                     Render-Atlanta
-                  </Link>{' '}
+                  </ExternalLink>{' '}
                   {FOUNDER_MESSAGE}
                   <br />
                   <List>
                     <ListItem>
-                      <Link
+                      <ExternalLink
                         variant="cta"
                         href="https://twitter.com/ThugDebugger"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         Twitter
-                      </Link>
+                      </ExternalLink>
                     </ListItem>
                     <ListItem>
-                      <Link
+                      <ExternalLink
                         variant="cta"
                         href="https://www.instagram.com/thugdebugger/"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         Instagram
-                      </Link>
+                      </ExternalLink>
                     </ListItem>
                     <ListItem>
-                      <Link
+                      <ExternalLink
                         variant="cta"
                         href="https://www.facebook.com/thugdebugger-109112997164763/"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         Facebook
-                      </Link>
+                      </ExternalLink>
                     </ListItem>
                   </List>
                 </>


### PR DESCRIPTION
# Describe your PR

Related to # https://github.com/Rebuild-Black-Business/RBB-Website/issues/229
Fixes #
Resolve this warning from Chakra UI:
External link https://www.instagram.com/clay.banks was detected in a Link component. Use the Link component only for internal links.

Creates an ExternalLink component to use Chakra links that aren't cast as Gatsby Link

## Pages/Interfaces that will change
All pages with external links (Footer with photo credits, about page, modals, etc)

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

n/a

## Steps to test

1. Navigate to different page on the site with external links like page with photocredits  in footer, about page and confirm links are still functional and proper style

### Additional notes
