### PR TITLE
Feature/smooth scroll to

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -5,6 +5,7 @@ import NoResultsCard from '../Cards/NoResultsCard';
 import BusinessFilter from '../Filters/BusinessFilter';
 import ResultCard from '../ResultCard';
 import CardSkeleton from '../Loading/CardSkeleton';
+import { scrollToId } from '../../utils/scrollToId';
 
 function BusinessFeed({ businesses, onSearch, selectedFilters }) {
   const theme = useTheme();
@@ -13,6 +14,14 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
   useEffect(() => {
     setLoaded(true);
   }, []);
+
+  useEffect(() => {
+    if (window && window.location.hash) {
+      window.setTimeout(() => {
+        scrollToId(window.location.hash);
+      }, 200);
+    }
+  }, [loaded]);
 
   return (
     <Box
@@ -26,7 +35,7 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
       {!loaded && <CardSkeleton data={businesses}></CardSkeleton>}
       {loaded && businesses.length > 0 ? (
         <>
-          <SimpleGrid columns={[null, 1, 2]} spacing={10}>
+          <SimpleGrid id="results" columns={[null, 1, 2]} spacing={10}>
             {businesses.map(business => {
               const formattedLocation = `${business.city ? business.city : ''}${
                 business.city && business.state ? ', ' : ''

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -89,7 +89,7 @@ function Pagination({ location, currentPage, totalPages }) {
    * @param {integer} page - new page number
    */
   function getPageLink(page) {
-    if (page === 1) return pathname;
+    if (page === 1) return `${pathname}#results`;
     return `${pathname}?${getUpdatedSearchParams(location.search, {
       page,
     })}#results`;
@@ -135,7 +135,7 @@ function Pagination({ location, currentPage, totalPages }) {
         const isActivePage = currentPage === page;
 
         return (
-          <a href={getPageLink(page)}>
+          <Link href={getPageLink(page)}>
             <Button
               key={index}
               display="flex"
@@ -155,7 +155,7 @@ function Pagination({ location, currentPage, totalPages }) {
             >
               {page}
             </Button>
-          </a>
+          </Link>
         );
       })}
       <PaginationArrow

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -90,7 +90,9 @@ function Pagination({ location, currentPage, totalPages }) {
    */
   function getPageLink(page) {
     if (page === 1) return pathname;
-    return `${pathname}?${getUpdatedSearchParams(location.search, { page })}`;
+    return `${pathname}?${getUpdatedSearchParams(location.search, {
+      page,
+    })}#results`;
   }
 
   const prevPageLink = getPageLink(currentPage - 1);
@@ -133,7 +135,7 @@ function Pagination({ location, currentPage, totalPages }) {
         const isActivePage = currentPage === page;
 
         return (
-          <Link to={getPageLink(page)}>
+          <a href={getPageLink(page)}>
             <Button
               key={index}
               display="flex"
@@ -153,7 +155,7 @@ function Pagination({ location, currentPage, totalPages }) {
             >
               {page}
             </Button>
-          </Link>
+          </a>
         );
       })}
       <PaginationArrow

--- a/src/pages/legal.js
+++ b/src/pages/legal.js
@@ -1,8 +1,9 @@
 import { Box, Flex, Heading } from '@chakra-ui/core';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '../components/Layout';
 import Privacy from '../docs/privacy-policy';
 import Terms from '../docs/terms-and-conditions';
+import { scrollToId } from '../utils/scrollToId';
 
 export default function About() {
   const legalData = [
@@ -17,6 +18,13 @@ export default function About() {
       body: <Privacy />,
     },
   ];
+
+  useEffect(() => {
+    if (window && window.location.hash) {
+      scrollToId(window.location.hash);
+    }
+  }, []);
+
   return (
     <Layout p="4">
       <Flex justify="center" direction="column" align="center">

--- a/src/utils/scrollToId.js
+++ b/src/utils/scrollToId.js
@@ -1,0 +1,11 @@
+export const scrollToId = id => {
+  const element = document.querySelector(id);
+  return (
+    element &&
+    window.scrollTo({
+      left: 0,
+      top: element.offsetTop - 20,
+      behavior: 'smooth',
+    })
+  );
+};


### PR DESCRIPTION
# Describe your PR
Gatsby Links don't support scrolling to hash ids in the url natively so I implemented a quick fix that is in use on Business and Legal pages. Needed to wrap business load in a timeout for more consistent experience.

Related to https://trello.com/c/QfHWbLi8/207-navigating-to-another-page-of-search-results-should-bring-you-to-the-results-portion-of-the-page-not-the-top-of-the-page-skip-th

## Pages/Interfaces that will change
Legal & Business

### Screenshots / video of changes
https://www.loom.com/share/b0666dedf72d421db9046e69be0f3b48

## Steps to test

1. Go to business page and scroll down to pagination on the bottom.
2. Click a page other than the currently active page
3. -> Smooth scroll to results section of new page 

===========

1. Go to allies page gate
2. Click Terms and Conditions link
3. -> Smooth scroll to TaC

### Additional notes
The arrow buttons don't seem to work with smooth scroll but they are taking the user to the results section directly.