### PR TITLE
Terms and conditions in new tab

### DIFF
--- a/src/pages/allies.js
+++ b/src/pages/allies.js
@@ -79,7 +79,7 @@ export default function Allies(props) {
                 </ModalHeader>
                 <ModalBody fontSize="lg" mt="8">
                   Please read and agree to our{' '}
-                  <Link variant="cta" href="/legal#terms">
+                  <Link variant="cta" href="/legal#terms" target="_blank">
                     terms and conditions
                   </Link>{' '}
                   to access our Ally list and contacts.


### PR DESCRIPTION
# Describe your PR
Terms and Conditions should open in a new tab or it breaks user flow

## Pages/Interfaces that will change
Ally gate

## Steps to test

1. Open ally gate
2. Click Terms and conditions
3. -> Link opens in new tab

### Additional notes
Based on comments in https://github.com/Rebuild-Black-Business/RBB-Website/pull/201 we decided to keep Terms and Conditions to have target="_blank".

Looks like it was removed as a side effect of this larger PR https://github.com/Rebuild-Black-Business/RBB-Website/pull/202