### PR TITLE
View directories link should be business directory, not ally directory

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -223,7 +223,7 @@ export default () => {
                 h="auto"
                 px="30px"
                 as={Link}
-                href="/allies"
+                href="/businesses"
               >
                 View Directory
               </Button>


### PR DESCRIPTION
# Describe your PR
View Directory link on Home Page goes to Business Directory instead of Ally Directory based on the surrounding text

## Pages/Interfaces that will change
Home page allies section

### Screenshots / video of changes
![image](https://user-images.githubusercontent.com/20157895/84465028-a33db680-ac3b-11ea-8e11-672aac2ba49e.png)


## Steps to test

1. Go to home page
2. Scroll down to Allies section
3. Click view directory
4. -> Taken to business directory
