### PR TITLE
Fix/Pagination hover effect sometimes persistent

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -92,12 +92,31 @@ function Pagination({ location, currentPage, totalPages }) {
     [...new Array(pages.length)].map(() => React.createRef())
   );
   const [refWithFocus, setRefWithFocus] = useState();
+  const [refWithHover, setRefWithHover] = useState();
 
-  // Blurres currently focused elem and then resets the state
-  function removeFocus() {
+  /**
+   * Sets state of the ref that currently is being hovered and unset state of refWithFocus to remove the focus styles when elem is being hovered
+   *
+   * @param {HTMLElement} elem
+   */
+  function addHoverRemoveFocus(elem) {
     if (refWithFocus) {
       refWithFocus.blur();
+      setRefWithHover(elem);
       setRefWithFocus(null);
+    }
+  }
+
+  /**
+   * Sets state of the ref that currently has focus and unset state of refWithHover to remove the hover styles when elem is being focused
+   *
+   * @param {HTMLElement} elem
+   */
+  function addFocusRemoveHover(elem) {
+    setRefWithFocus(elem);
+
+    if (refWithHover) {
+      setRefWithHover(null);
     }
   }
 
@@ -167,11 +186,16 @@ function Pagination({ location, currentPage, totalPages }) {
               fontWeight={theme.fontWeights.bold}
               cursor="pointer"
               _focus={{ bg: !isActivePage && theme.colors['rbb-lightgray'] }}
-              _hover={{ bg: !isActivePage && theme.colors['rbb-lightgray'] }}
+              _hover={{
+                bg:
+                  !isActivePage &&
+                  refWithHover &&
+                  theme.colors['rbb-lightgray'],
+              }}
               title={`Go to page ${page}`}
               aria-label={`Go to page ${page}`}
-              onFocus={() => setRefWithFocus(refs.current[index])}
-              onMouseEnter={removeFocus}
+              onFocus={() => addFocusRemoveHover(refs.current[index])}
+              onMouseEnter={() => addHoverRemoveFocus(refs.current[index])}
             >
               {page}
             </Button>

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState, useEffect } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { Button, Flex, PseudoBox, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import useMedia from 'react-use/lib/useMedia';

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { Button, Flex, PseudoBox, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import useMedia from 'react-use/lib/useMedia';
@@ -85,6 +85,22 @@ function Pagination({ location, currentPage, totalPages }) {
     return range(1, totalPages);
   }, [currentPage, totalPages, pageNeighbors]);
 
+  /**
+   * Need to store a ref of each pagination link to handle removing focused styles when hovering
+   */
+  const refs = useRef(
+    [...new Array(pages.length)].map(() => React.createRef())
+  );
+  const [refWithFocus, setRefWithFocus] = useState();
+
+  // Blurres currently focused elem and then resets the state
+  function removeFocus() {
+    if (refWithFocus) {
+      refWithFocus.blur();
+      setRefWithFocus(null);
+    }
+  }
+
   // check to make sure pagination doesn't crash out pages that accidentally include it
   if (!location) return null;
   const pathname = location.pathname;
@@ -139,6 +155,7 @@ function Pagination({ location, currentPage, totalPages }) {
         return (
           <Link to={getPageLink(page)} key={index}>
             <Button
+              ref={el => (refs.current[index] = el)}
               display="flex"
               justifyContent="center"
               alignItems="center"
@@ -153,6 +170,8 @@ function Pagination({ location, currentPage, totalPages }) {
               _hover={{ bg: !isActivePage && theme.colors['rbb-lightgray'] }}
               title={`Go to page ${page}`}
               aria-label={`Go to page ${page}`}
+              onFocus={() => setRefWithFocus(refs.current[index])}
+              onMouseEnter={removeFocus}
             >
               {page}
             </Button>


### PR DESCRIPTION
# Describe your PR
The ticket states:
> Chrome, desktop and mobile - at times, the hover effect on pagination stays even after cursor no longer hovered / after click.

The only way I was able to reproduce was clicking on a link then tabbing (see `Steps to test` for more deets) to have the effect persist. But it makes sense that this would be a problem when you look at [these two lines](https://github.com/Rebuild-Black-Business/RBB-Website/blob/446b87b2781f81155886e617eefaf1fdcfc9edae/src/components/Pagination/Pagination.jsx#L148-L149) - it's very possible for both the hover and focus state to occur simultaneously. So what I ended up doing is storing refs to each pagination page button element to handle blurring the currently focused ref when user starts hovering to prevent simultaneous active states for hover and focus.

Ticket: https://trello.com/c/zxapOTEw/139-pagination-hover-effect-sometimes-persistent

## Pages/Interfaces that will change
This affects the pagination page links, both the hover and focus states.

### Screenshots / video of changes

| Before (buggy) | After (fix) |
|-|-|
|[screencap from ticket](https://trello-attachments.s3.amazonaws.com/5ed7c609e0fa8c77ca90e9ff/5ee148f4281b312695f94401/f5d87ca253af89a3fd3309ae4181759e/rbb_pagination.gif)| [screencap from local](https://share.getcloudapp.com/6qu2LkA2)|

## Steps to test
*To recreate the bug*:
1. Go to /businesses
2. Scroll down to pagination element
3. click a page (that will set focus to that elem
4. spam tab key to tab through the pages (tab will set focus to the <a> then the <button> that's why you have to press twice in order to go to the next page number). So press tab until the <button> has focus and it'll have the gray bg color.
5. Try hovering over any other pages, the focused button will still have gray bg while the currently hovered item will _also_ have a gray bg.

For the fix - do the same steps above^ , except this time, the focus is removed from the element when you start hovering.

### Additional notes
Not gonna lie, it's been a minute since I've done some more complex react work, so I relied on [this guide](https://erikmartinjordan.com/multiple-refs-array-hooks) for this solution 😅 