### PR TITLE
Prevent additional algolia requests by circumventing gatsby `navigate`

### DIFF
--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { navigate } from 'gatsby';
 
 import {
   Flex,
@@ -34,7 +33,7 @@ const ModalForm = ({ isOpen, onClose }) => (
   </Modal>
 );
 
-function generateURL(filters, location) {
+function generateURL(filters) {
   let newPath = '/businesses';
 
   if (filters.need === 'false') {
@@ -49,7 +48,7 @@ function generateURL(filters, location) {
     newPath += `?location=${filters.location}`;
   }
 
-  navigate(newPath);
+  window.history.replaceState({}, undefined, newPath);
 }
 
 function searchingInNeed(location) {


### PR DESCRIPTION
Using the business filters add an additional XHR request with empty coordinates. This has potential to cause a race condition with rendering where location-filtered results will show and then unfiltered results will jump into view.

There is some nuance to this that I don't fully understand, but it something to do with how `navigate` is causing a full `Business` component re-render.

## Pages/Interfaces that will change

/businesses

### Screenshots / video of changes

Before video of additional XHR requests: https://share.getcloudapp.com/6qu2LWJR
After video: https://share.getcloudapp.com/2Nu5r2Ro

## Steps to test

- Go to businesses page
- Search for Portland and submit
- Change "show me" to all and submit

