### PR TITLE
Stop the pagination page 1 from removing location

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -10,7 +10,12 @@ const PLACEHOLDER = '...';
 
 function getUpdatedSearchParams(searchString, { page }) {
   const searchParams = new URLSearchParams(searchString);
-  searchParams.set('page', page);
+
+  if (page === 1) {
+    searchParams.delete('page');
+  } else {
+    searchParams.set('page', page);
+  }
   return searchParams.toString();
 }
 
@@ -89,7 +94,6 @@ function Pagination({ location, currentPage, totalPages }) {
    * @param {integer} page - new page number
    */
   function getPageLink(page) {
-    if (page === 1) return pathname;
     return `${pathname}?${getUpdatedSearchParams(location.search, { page })}`;
   }
 


### PR DESCRIPTION
When you went to page 1 in the pagination it would clear all url
parameters, which was lazyness on my side when I implemented it,
didn't think of this use case.

Tgis fix ensures that we only remove the pages search param on page 1.

