### PR TITLE
Move from navigate to window.locate for search filters

### DIFF
--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -6,6 +6,8 @@ function usePagination(location, onChange) {
   useEffect(() => {
     const pageParam = new URLSearchParams(location.search).get('page');
 
+    // Duplicated because otherwise it wants it to be inside useEffect
+    // And then that gets complex. Easier this way for now!
     if (pageParam) {
       setPage(pageParam);
       onChange(pageParam);
@@ -15,7 +17,7 @@ function usePagination(location, onChange) {
     }
   }, [location.search, onChange]);
 
-  return page;
+  return { page };
 }
 
 export default usePagination;

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -6,8 +6,6 @@ function usePagination(location, onChange) {
   useEffect(() => {
     const pageParam = new URLSearchParams(location.search).get('page');
 
-    // Duplicated because otherwise it wants it to be inside useEffect
-    // And then that gets complex. Easier this way for now!
     if (pageParam) {
       setPage(pageParam);
       onChange(pageParam);


### PR DESCRIPTION
Navigate in Gatsby was causing a full rerender of the page on trigger,
which meant that n1, you were pushed to the top of the page quite
violently every time you did a search but also with a search being
programatically triggered, it would then get retriggered by the page
refresh. There would then be a race condition and everything got a bit
strange.

One way to solve this would have been to stuck with just using page
refreshes however I much prefer a dynamic search without jumping around
all over the place so went in that direction.

I have stored a page location object which I updated with the new path
name and search params when filters change the URL which allows it to
act like navigate for the pagination which uses page location. I could
have setup pagination to then change page dynamically as well but then
you need to scroll to things and page refreshing is an easy way to skip
all that. Also means the pagination would not have been as easily
reusable.

Its a bit of a Frakensteins monster, however I hope it makes sense!
Happy for any review comments/ideas.

# Describe your PR

Related to #
Fixes #

## Pages/Interfaces that will change

### Screenshots / video of changes

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1.

### Additional notes
