### PR TITLE
Change homepage modals to links?

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,11 +2,15 @@ export { default as AllyFeed } from './Feeds/AllyFeed';
 export { default as AllyFilter } from './Filters/AllyFilter';
 export { default as BusinessFeed } from './Feeds/BusinessFeed';
 export { default as Button } from './Buttons/PrimaryButton';
+export { default as ContentBlock } from './ContentBlock';
 export { default as Image } from './Image';
+export { default as Link } from './Link.js';
 export { default as Layout } from './Layout';
 export { default as PageHero } from './PageHero';
 export { default as Pagination } from './Pagination/Pagination';
 export { default as SEO } from './SEO/SEO';
+export { default as SubmitAlly } from './Forms/SubmitAlly';
+export { default as SubmitBusiness } from './Forms/SubmitBusiness';
 
 // headings
 export { default as PageHeading } from './Headings/PageHeading';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,11 +14,15 @@ import {
   useTheme,
 } from '@chakra-ui/core';
 import React, { useState } from 'react';
-import Button from '../components/Button';
-import ContentBlock from '../components/ContentBlock';
-import SubmitAlly from '../components/Forms/SubmitAlly';
-import SubmitBusiness from '../components/Forms/SubmitBusiness';
-import Layout from '../components/Layout';
+
+import {
+  Button,
+  ContentBlock,
+  Layout,
+  SubmitAlly,
+  SubmitBusiness,
+} from '../components';
+
 import { VOLUNTEER_URL } from '../constants/about';
 
 const InfoModal = ({ isOpen, onClose, modalType }) => (
@@ -42,6 +46,18 @@ export default () => {
   const handleType = newType => {
     setModalType(newType);
     onOpen();
+  };
+
+  const ctaButtonStyle = {
+    backgroundColor: theme.colors['rbb-orange'],
+    borderColor: '#C34D2B',
+    textDecoration: 'none',
+  };
+
+  const secondaryButtonStyle = {
+    backgroundColor: theme.colors['rbb-white'],
+    color: theme.colors['rbb-black-200'],
+    textDecoration: 'none',
   };
 
   return (
@@ -97,12 +113,13 @@ export default () => {
             </Text>
             <ButtonGroup spacing={4} mt={theme.spacing.base}>
               <Button
+                as={Link}
+                href={'/businesses'}
+                style={ctaButtonStyle}
                 variant="cta"
                 m={3}
                 h="auto"
                 px="30px"
-                onClose={onClose}
-                onClick={() => handleType('business')}
               >
                 I need help
               </Button>
@@ -159,13 +176,14 @@ export default () => {
             </Box>
             <ButtonGroup spacing={4} mt={theme.spacing.base}>
               <Button
+                as={Link}
+                href={'/businesses'}
+                style={{ textDecoration: 'none' }}
                 variant="primary"
                 maxW="230px;"
                 m={3}
                 h="auto"
                 px="30px"
-                onClose={onClose}
-                onClick={() => handleType('business')}
               >
                 Add Business
               </Button>
@@ -176,6 +194,7 @@ export default () => {
                 px="30px"
                 as={Link}
                 href="/allies"
+                style={secondaryButtonStyle}
               >
                 See Allies
               </Button>
@@ -228,13 +247,14 @@ export default () => {
                 View Directory
               </Button>
               <Button
+                as={Link}
+                href="/allies"
+                style={{ textDecoration: 'none' }}
                 variant="secondary"
                 maxW="230px"
                 m={3}
                 h="auto"
                 px="30px"
-                onClose={onClose}
-                onClick={() => handleType('ally')}
               >
                 Sign up as an Ally
               </Button>
@@ -269,6 +289,7 @@ export default () => {
             </Text>
             <Button
               variant="cta"
+              style={ctaButtonStyle}
               as={Link}
               href={VOLUNTEER_URL}
               mt={theme.spacing.base}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -121,18 +121,7 @@ export default () => {
                 h="auto"
                 px="30px"
               >
-                I need help
-              </Button>
-              <Button
-                as={Link}
-                href="/allies"
-                variant="primary"
-                style={{ textDecoration: 'none' }}
-                m={3}
-                h="auto"
-                px="30px"
-              >
-                I can help
+                See Businesses
               </Button>
             </ButtonGroup>
           </Box>
@@ -169,32 +158,18 @@ export default () => {
                 you are doing well, we're here to help.
               </Text>
               <Text fontFamily={theme.fonts.heading} lineHeight="1.25">
-                You can add your business to our online directory of Black-owned
-                businesses. You can also contact one of our registered Allies
-                directly for help. <strong>We are all in this together.</strong>
+                Contact one of our registered Allies directly for help.{' '}
+                <strong>We are all in this together.</strong>
               </Text>
             </Box>
             <ButtonGroup spacing={4} mt={theme.spacing.base}>
               <Button
-                as={Link}
-                href={'/businesses'}
-                style={{ textDecoration: 'none' }}
                 variant="primary"
-                maxW="230px;"
-                m={3}
-                h="auto"
-                px="30px"
-              >
-                Add Business
-              </Button>
-              <Button
-                variant="secondary"
                 m={3}
                 h="auto"
                 px="30px"
                 as={Link}
                 href="/allies"
-                style={secondaryButtonStyle}
               >
                 See Allies
               </Button>
@@ -244,7 +219,7 @@ export default () => {
                 as={Link}
                 href="/businesses"
               >
-                View Directory
+                See Businesses
               </Button>
               <Button
                 as={Link}
@@ -254,6 +229,7 @@ export default () => {
                 maxW="230px"
                 m={3}
                 h="auto"
+                style={secondaryButtonStyle}
                 px="30px"
               >
                 Sign up as an Ally


### PR DESCRIPTION
# Describe your PR
Marking this as a draft PR since its validity is still in discussion in trello/discord.

I don't believe there is a trello card here, but there's been some discussion on [discord](https://discordapp.com/channels/717124695979458570/717759884921143389/720993078890070067)


This PR changes the modal actions on the home page to links.  

It also features a fair bit of tech debt:
- the button component we're using on the home page to create pill buttons doesn't seem to style things correctly when `as={Link}` is used
- when `as={Link}` is used, we should have the option to use a `to={someLocalUrl}` prop to take advantage of gatsby's `Link` component, which is far more performant than a standard anchor URL link
- I left the code to support modals on the homepage intact. There will be some eslint yelling as a result

## Pages/Interfaces that will change
/home

### Screenshots / video of changes

n/a really, check the deploy preview - three buttons on the homepage are now links

## Steps to test

1.

### Additional notes
