### PR TITLE
Hotfix/205 when changing search type returns all results + some fixes

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -3,30 +3,28 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import NoResultsCard from '../Cards/NoResultsCard';
 import BusinessFilter from '../Filters/BusinessFilter';
+import { LOADING_STATE } from '../../hooks/useAlgoliaSearch';
+
 import ResultCard from '../ResultCard';
-import CardSkeleton from '../Loading/CardSkeleton';
 
-function BusinessFeed({ businesses, onSearch, selectedFilters }) {
+function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
   const theme = useTheme();
-  const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
-    setLoaded(true);
-  }, []);
+  const loaded = loadingState === LOADING_STATE.NONE;
+  const initialLoad = loadingState === LOADING_STATE.INITIAL;
+  const hasResults = businesses.length > 0;
 
   return (
     <Box
       maxW={theme.containers.main}
       paddingX={[null, theme.spacing.base, theme.spacing.lg]}
     >
-      {!loaded && <CardSkeleton data={businesses}></CardSkeleton>}
-      {loaded && (
-        <BusinessFilter
-          onSearch={filters => onSearch(filters)}
-          selectedFilters={selectedFilters}
-        />
-      )}
-      {loaded && businesses.length > 0 ? (
+      <BusinessFilter
+        onSearch={filters => onSearch(filters)}
+        selectedFilters={selectedFilters}
+        isSearching={loadingState === LOADING_STATE.SEARCHING}
+      />
+      {!initialLoad && hasResults && (
         <>
           <SimpleGrid columns={[null, 1, 2]} spacing={10}>
             {businesses.map(business => {
@@ -47,9 +45,8 @@ function BusinessFeed({ businesses, onSearch, selectedFilters }) {
             })}
           </SimpleGrid>
         </>
-      ) : (
-        <NoResultsCard type="businesses" />
       )}
+      {loaded && !hasResults && <NoResultsCard type="businesses" />}
       <Box
         display="flex"
         justifyContent="flex-end"
@@ -98,6 +95,7 @@ BusinessFeed.propTypes = {
   businesses: PropTypes.arrayOf(PropTypes.object),
   onSearch: PropTypes.func.isRequired,
   selectedFilters: PropTypes.object.isRequired,
+  loadingState: PropTypes.object.isRequired,
 };
 
 export default BusinessFeed;

--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -1,6 +1,6 @@
 import { Box, SimpleGrid, useTheme } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import NoResultsCard from '../Cards/NoResultsCard';
 import BusinessFilter from '../Filters/BusinessFilter';
 import { LOADING_STATE } from '../../hooks/useAlgoliaSearch';

--- a/src/components/Filters/BusinessFilter.jsx
+++ b/src/components/Filters/BusinessFilter.jsx
@@ -6,6 +6,7 @@ import {
   Select,
   useTheme,
 } from '@chakra-ui/core';
+import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { handleLocationToCoords } from '../../api/geocode';
 import PrimaryButton from '../Buttons/PrimaryButton';
@@ -19,8 +20,7 @@ const businessTypes = [
   { id: 'other', label: 'Other' },
 ];
 
-function BusinessFilter(props) {
-  const { onSearch, selectedFilters } = props;
+function BusinessFilter({ isSearching, onSearch, selectedFilters }) {
   const [location, setLocation] = useState(selectedFilters.location || '');
   const typeRef = useRef();
   const needRef = useRef();
@@ -142,6 +142,7 @@ function BusinessFilter(props) {
                 handleSearchKeyPress(event);
               }
             }}
+            isLoading={isSearching}
           >
             Search
           </PrimaryButton>
@@ -150,5 +151,11 @@ function BusinessFilter(props) {
     </FormControl>
   );
 }
+
+BusinessFilter.propTypes = {
+  isSearching: PropTypes.bool,
+  onSearch: PropTypes.func.isRequired,
+  selectedFilters: PropTypes.object.isRequired,
+};
 
 export default BusinessFilter;

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -19,6 +19,7 @@ export default function Image(props) {
         // fetch: 'auto' is applied internally
         // crop: 'scale' is applied automatically when a width or height is supplied
         quality: 'auto',
+        dpr: 2,
       },
     });
   }, [publicId]);

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -134,6 +134,7 @@ const ResultCard = forwardRef(
             publicId={!imageSrc ? categoryData[catVar]?.image.src : null}
             src={imageSrc ? imageSrc : null}
             alt={imageAlt || categoryData[catVar]?.image.alt}
+            transforms={{ width: 500, height: 350, crop: 'fit', dpr: 2 }}
           />
         )}
         <CardContent

--- a/src/hooks/useAlgoliaSearch.js
+++ b/src/hooks/useAlgoliaSearch.js
@@ -36,27 +36,17 @@ function useAlgoliaSearch(filters, page) {
   const [loadingState, setLoadingState] = useState(LOADING_STATE.INITIAL);
   const [totalPages, setTotalPages] = useState(0);
   const [totalResults, setTotalResults] = useState(0);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [searchFilters, setSearchFilters] = useState(filters);
 
   const defaultFilters = `approved=1`;
-
-  useMemo(() => {
-    setSearchFilters(filters);
-  }, [filters]);
-
-  useMemo(() => {
-    setCurrentPage(page);
-  }, [page]);
 
   useEffect(() => {
     async function getBusinesses() {
       try {
         const algoliaResponse = await index.search('', {
-          page: currentPage - 1,
-          filters: createFilterString(defaultFilters, searchFilters),
-          aroundLatLng: Object.keys(searchFilters.coordinates).length
-            ? `${searchFilters.coordinates.lat}, ${searchFilters.coordinates.lng}`
+          page: page - 1,
+          filters: createFilterString(defaultFilters, filters),
+          aroundLatLng: Object.keys(filters.coordinates).length
+            ? `${filters.coordinates.lat}, ${filters.coordinates.lng}`
             : '',
           aroundRadius: 40000, // 40 km -- Note: Please change this I didn't know how far to search!
         });
@@ -71,7 +61,7 @@ function useAlgoliaSearch(filters, page) {
     }
 
     getBusinesses();
-  }, [currentPage, defaultFilters, searchFilters]);
+  }, [page, defaultFilters, filters]);
 
   return {
     results,

--- a/src/hooks/useAlgoliaSearch.js
+++ b/src/hooks/useAlgoliaSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import algoliasearch from 'algoliasearch/lite';
 
 const client = algoliasearch(

--- a/src/hooks/useAlgoliaSearch.js
+++ b/src/hooks/useAlgoliaSearch.js
@@ -35,7 +35,6 @@ function useAlgoliaSearch(filters, page) {
   const [results, setResults] = useState([]);
   const [loadingState, setLoadingState] = useState(LOADING_STATE.INITIAL);
   const [totalPages, setTotalPages] = useState(0);
-  const [totalResults, setTotalResults] = useState(0);
 
   const defaultFilters = `approved=1`;
 
@@ -53,7 +52,6 @@ function useAlgoliaSearch(filters, page) {
 
         setResults(algoliaResponse.hits);
         setTotalPages(algoliaResponse.nbPages);
-        setTotalResults(algoliaResponse.nbHits);
         setLoadingState(LOADING_STATE.NONE);
       } catch (e) {
         console.log('error searching', e);
@@ -66,8 +64,8 @@ function useAlgoliaSearch(filters, page) {
   return {
     results,
     totalPages,
-    totalResults,
     loadingState,
+    setLoadingState,
   };
 }
 

--- a/src/hooks/useAlgoliaSearch.js
+++ b/src/hooks/useAlgoliaSearch.js
@@ -31,7 +31,7 @@ function createFilterString(defaultFilters = '', filters) {
   return filterArr.join(' AND ');
 }
 
-function useAlgoliaSearch(filters) {
+function useAlgoliaSearch(filters, page) {
   const [results, setResults] = useState([]);
   const [loadingState, setLoadingState] = useState(LOADING_STATE.INITIAL);
   const [totalPages, setTotalPages] = useState(0);
@@ -44,6 +44,10 @@ function useAlgoliaSearch(filters) {
   useMemo(() => {
     setSearchFilters(filters);
   }, [filters]);
+
+  useMemo(() => {
+    setCurrentPage(page);
+  }, [page]);
 
   useEffect(() => {
     async function getBusinesses() {
@@ -74,7 +78,6 @@ function useAlgoliaSearch(filters) {
     totalPages,
     totalResults,
     loadingState,
-    setSearchPage: setCurrentPage,
   };
 }
 

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-function usePagination(location, onChange) {
+function usePagination(location) {
   const [page, setPage] = useState(1);
 
   useEffect(() => {
@@ -11,9 +11,9 @@ function usePagination(location, onChange) {
     } else {
       setPage(1);
     }
-  }, [location, onChange]);
+  }, [location]);
 
-  return page;
+  return { page };
 }
 
 export default usePagination;

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -8,12 +8,10 @@ function usePagination(location, onChange) {
 
     if (pageParam) {
       setPage(pageParam);
-      onChange(pageParam);
     } else {
       setPage(1);
-      onChange(1);
     }
-  }, [location.search, onChange]);
+  }, [location, onChange]);
 
   return { page };
 }

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -91,15 +91,11 @@ export default function Businesses(props) {
     coordinates: {},
   });
 
-  const { results, totalPages, setSearchPage } = useAlgoliaSearch(
-    searchFilters
-  );
-  const { page } = usePagination(pageLocation, newPage => {
-    setSearchPage(newPage);
-  });
-  const theme = useTheme();
-
+  // Do this before we start searching and paginating
   useEffect(() => {
+    // Make sure it gets updated on page navigation
+    setPageLocation(props.location);
+
     // Does not use pageLocation as it should only run on first load.
     async function setLocationCoordinatesFromURL() {
       const coordinates = await searchCoordinates(props.location);
@@ -110,6 +106,11 @@ export default function Businesses(props) {
     }
     setLocationCoordinatesFromURL();
   }, [props.location]);
+
+  const { page } = usePagination(pageLocation);
+  const { results, totalPages } = useAlgoliaSearch(searchFilters, page);
+
+  const theme = useTheme();
 
   function onSearch(filters) {
     setSearchFilters(filters);

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -16,7 +16,7 @@ import Pagination from '../components/Pagination';
 
 import { handleLocationToCoords } from '../api/geocode';
 
-import useAlgoliaSearch from '../hooks/useAlgoliaSearch';
+import useAlgoliaSearch, { LOADING_STATE } from '../hooks/useAlgoliaSearch';
 import usePagination from '../hooks/usePagination';
 import SubmitBusiness from '../components/Forms/SubmitBusiness';
 import Button from '../components/Button';
@@ -109,9 +109,15 @@ export default function Businesses(props) {
   }, [props.location]);
 
   const { page } = usePagination(pageLocation);
-  const { results, totalPages } = useAlgoliaSearch(searchFilters, page);
+  const {
+    results,
+    totalPages,
+    loadingState,
+    setLoadingState,
+  } = useAlgoliaSearch(searchFilters, page);
 
   function onSearch(filters) {
+    setLoadingState(LOADING_STATE.SEARCHING);
     generateURL(filters, setPageLocation);
     setSearchFilters(filters);
   }
@@ -171,15 +177,16 @@ export default function Businesses(props) {
           businesses={results}
           onSearch={onSearch}
           selectedFilters={searchFilters}
+          loadingState={loadingState}
         />
 
-        {results.length ? (
+        {!!results.length && (
           <Pagination
             location={pageLocation}
             currentPage={parseInt(page)}
             totalPages={parseInt(totalPages)}
           />
-        ) : null}
+        )}
       </Flex>
     </>
   );

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import {
   Flex,


### PR DESCRIPTION
Original bug: When changing search type to all from in need with predefined search parameters it just returns all results.

So the fix for the above bug was released and then reverted because it
broke pagination. I have now tested pagination to death AND fixed the bug
where multiple algolia requests were being made on page change that
created a race condition and then broke things. SO hopefully we have
fixed many things.

--- Additional Extras ----
Basically a tidying things up that were annoying me commit.

Added a loading state to the spinner, seemed to come in the UI library
so was pretty easy to add.

Fixed the no results flash so that it will only show we we have
confirmed that there really are no results.

Resized the images to an appropriate size and set DPR to 2 so they can
be retina.

Related to: https://github.com/Rebuild-Black-Business/RBB-Website/pull/253
Fixes 
- https://trello.com/c/QNWA1y7N/205-when-changing-search-type-to-all-from-in-need-with-predefined-search-parameters-it-just-returns-all-results
- https://trello.com/c/KyTSKyl7/233-sorry-no-business-matched-this-search
- https://trello.com/c/1u0qaP7O/229-business-images-in-the-business-feed-are-5-6-times-bigger-than-they-need-to-be

## Pages/Interfaces that will change
- Businesses page

## Steps to test

Process:
- Go to businesses page
- Search for Portland and submit
- Search for all and submit

Expected Result:
- Would show the number of pages for results in Portland

### Additional notes
