### PR TITLE
Fix/pagination focus hits two elements

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -126,10 +126,18 @@ function Pagination({ location, currentPage, totalPages }) {
 
   /**
    * Create the correct page link
+   * Only adds '?' to url when page is > 1
+   *
    * @param {integer} page - new page number
    */
   function getPageLink(page) {
-    return `${pathname}?${getUpdatedSearchParams(location.search, { page })}`;
+    const params = getUpdatedSearchParams(location.search, { page });
+
+    if (params) {
+      return `${pathname}?${params}`;
+    }
+
+    return pathname;
   }
 
   const prevPageLink = getPageLink(currentPage - 1);
@@ -142,6 +150,7 @@ function Pagination({ location, currentPage, totalPages }) {
       marginTop={theme.spacing.lg}
       marginBottom={theme.spacing.lg}
       marginX={theme.spacing.lg}
+      role="navigation"
     >
       <PaginationArrow
         hidden={currentPage === 1}
@@ -172,34 +181,34 @@ function Pagination({ location, currentPage, totalPages }) {
         const isActivePage = currentPage === page;
 
         return (
-          <Link to={getPageLink(page)} key={index}>
-            <Button
-              ref={el => (refs.current[index] = el)}
-              display="flex"
-              justifyContent="center"
-              alignItems="center"
-              width={10}
-              height={10}
-              backgroundColor={isActivePage && theme.colors['rbb-orange']}
-              fontFamily={theme.fonts['heading-slab']}
-              fontSize={theme.fontSizes.lg}
-              fontWeight={theme.fontWeights.bold}
-              cursor="pointer"
-              _focus={{ bg: !isActivePage && theme.colors['rbb-lightgray'] }}
-              _hover={{
-                bg:
-                  !isActivePage &&
-                  refWithHover &&
-                  theme.colors['rbb-lightgray'],
-              }}
-              title={`Go to page ${page}`}
-              aria-label={`Go to page ${page}`}
-              onFocus={() => addFocusRemoveHover(refs.current[index])}
-              onMouseEnter={() => addHoverRemoveFocus(refs.current[index])}
-            >
-              {page}
-            </Button>
-          </Link>
+          <Button
+            key={index}
+            as={Link}
+            to={getPageLink(page)}
+            ref={el => (refs.current[index] = el)}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            width={10}
+            height={10}
+            backgroundColor={isActivePage && theme.colors['rbb-orange']}
+            fontFamily={theme.fonts['heading-slab']}
+            fontSize={theme.fontSizes.lg}
+            fontWeight={theme.fontWeights.bold}
+            cursor="pointer"
+            _focus={{ bg: !isActivePage && theme.colors['rbb-lightgray'] }}
+            _hover={{
+              bg:
+                !isActivePage && refWithHover && theme.colors['rbb-lightgray'],
+            }}
+            title={`Go to page ${page}`}
+            aria-label={`Go to page ${page}`}
+            aria-current={isActivePage ? 'page' : null}
+            onFocus={() => addFocusRemoveHover(refs.current[index])}
+            onMouseEnter={() => addHoverRemoveFocus(refs.current[index])}
+          >
+            {page}
+          </Button>
         );
       })}
       <PaginationArrow

--- a/src/components/Svgs/PaginationArrow.js
+++ b/src/components/Svgs/PaginationArrow.js
@@ -33,26 +33,23 @@ const PaginationArrow = ({ hidden, direction, linkTo }) => {
         color: 'rbb-white',
       }}
     >
-      <Link to={linkTo}>
-        <IconButton
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          aria-label={`Go to ${
-            direction === 'NEXT' ? 'next' : 'previous'
-          } page`}
-          variant="unstyled"
-          icon={direction === 'NEXT' ? 'arrowRight' : 'arrowLeft'}
-          fontSize="28px"
-          minWidth={0}
-        />
-      </Link>
+      <IconButton
+        as={Link}
+        to={linkTo}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        aria-label={`Go to ${direction === 'NEXT' ? 'next' : 'previous'} page`}
+        variant="unstyled"
+        icon={direction === 'NEXT' ? 'arrowRight' : 'arrowLeft'}
+        fontSize="28px"
+        minWidth={0}
+      />
     </PseudoBox>
   );
 };
 
 PaginationArrow.propTypes = {
-  isDisabled: PropTypes.bool.isRequired,
   direction: PropTypes.oneOf(['PREVIOUS', 'NEXT']).isRequired,
   linkTo: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
# Describe your PR
In #245 I fixed some pagination hover/focus styling issues, but there was some apparent tabbing issues (as noted by reviewers 🙏 ). Basically, it takes two tab presses in order to get to the next/prev pagination link - it should only take one, which is what this PR addresses.

As @magnificode mentions, this is caused by the Button component (`<button>`) being wrapped in an Link component (`<a>`) and both of these elements are naturally tabbable elements, so the fix was to remove one of them - or better yet - combine them! 😮 Was able to maintain the Button styles, and turn it into a clickable link by setting it `as={Link}` and removing the `<Link>` component. I made this change for the pagination links and the pagination arrows as well.

While I was in here, I fixed up two minor things as well related to pagination:
1. In the dev tools console, there was an error regarding `isDisabled` is a required prop in `PaginationArrow`, but it didn't look like that prop was being used at all, so I removed it from `propTypes` so that it didn't continue to yell about it being required.
2. The `getPageLink` func was returning a url with a `?` even if there were no params (like when page=1) bc `getUpdatedSearchParams` returns an empty string when page=1. So I just added a condition to only return the url with `?` if it has param.

Related to Trello ticket # https://trello.com/c/NkrJyrQ2/206-pagination-focus-hits-two-elements

## Pages/Interfaces that will change
Affects tabbing on Pagination links
Before: it took two tab presses to nav to the next pagination link
After: it will take one tab press to nav to next pagination link

### Screenshots / video of changes

| pic of what screen readers pic up (via firefox) | vid of tabbing once to nav from link to link |
|-|-|
| https://share.getcloudapp.com/Wnubb5Kj | https://share.getcloudapp.com/E0uzzNKX |

| pagination link for page=1 (before) | pagination link for page=1 (after) |
|-|-|
|https://share.getcloudapp.com/rRulldbJ|https://share.getcloudapp.com/2Nu55QlZ|

## Steps to test
1. go to /businesses
2. click on a pagination page link
3. scroll back down to pagination component and start tabbing - should only only take one tab press now to move to the next link

## Additional Notes
- I used this [a11y style guide](https://a11y-style-guide.com/style-guide/section-navigation.html#kssref-navigation-pagination) as a guide.
- So TIL that firefox actually defers tab controls to the operating system and on MacOS it's not enabled by default, so there are two solutions to enabling tabbing to links in Firefox as outlined in this [stackoverflow thread](https://stackoverflow.com/a/11713537).
- Some additional info from [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/accessibility.tabfocus) on tabfocus
