### PR TITLE
Mobile/desktop ally and businesses "search" button text is off vertical center

### DIFF
--- a/src/components/Buttons/PrimaryButton.js
+++ b/src/components/Buttons/PrimaryButton.js
@@ -7,6 +7,7 @@ function PrimaryButton(props) {
   return (
     <Button
       {...props}
+      as="a"
       bg={theme.buttons.primary.backgroundColor.default}
       color={theme.buttons.primary.color.default}
       borderRadius="button"


### PR DESCRIPTION
# Describe your PR
The text alignment of the "search" text in the business and ally filter components are vertically misaligned on Safari (iOS & desktop), as specified in [the Trello ticket](https://trello.com/c/gtuMJ9t4/227-safari-mobile-ally-and-businesses-search-button-text-is-off-vertical-center). After digging in, apparently `flex` styles do not work on `button` or `fieldset` elements in Safari, as mentioned in this [stackoverflow thread](https://stackoverflow.com/a/44756423) (TIL this was a problem). Changing the `Button` component to render as an anchor tag did in fact fix the issue.

In this PR, I added `as="a"` to the `PrimaryButton` component to render a `<a type="button">` instead of `<button>` to allow `flex` layout styles to work as expected, and made the change there to prevent future uses of `PrimaryButton` elsewhere.

## Pages/Interfaces that will change
Afaik, the `businessFilter` and `allyFilter` are the only areas that are using a flex-styled `<button>`, which will change to a `<a type="button">`

### Screenshots / video of changes

| Before (prod on safari) | After (local on safari |
|-|-|
|https://share.getcloudapp.com/8Lu7n0Nk|https://share.getcloudapp.com/Z4uYqApD|

## Steps to test
1. Open safari
2. Navigate to /businesses or /allies
3. Locate the "search" button, above the search results
4. Can verify text is vertically aligned by comparing it to prod in Chrome

### Additional notes
- [caniuse](https://caniuse.com/#feat=flexbox) looks to be incorrectly displaying that the flex layout props should be working as expected on latest safari 😬 
- There's actually multiple ways of solving this. I went for the road of less changes 😅 , but this [readme](https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers) shares which elements can't use flex on which browsers. Also shares workaround for them, until a fix is distributed. I'm def not married to my attempt - I am open to other solutions!