### PR TITLE
fix whitespace block issue in allies page

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -20,7 +20,10 @@ export default function Layout({ children }) {
               logoInformation={data.site.siteMetadata.logo}
             />
             <SkipNavContent />
-            <main id="primary-content" style={{ maxWidth: '100vw' }}>
+            <main
+              id="primary-content"
+              style={{ maxWidth: '100vw', minHeight: 'calc(100vh - 475px)' }}
+            >
               {children}
             </main>
             <Footer />


### PR DESCRIPTION
# Describe your PR
Fix issue in the `allies` page where if you did not accept the terms and conditions, there will be a whitespace block at the end of the page. This has been fixed by giving the `main` element in `layout.js` a `minHeight: calc(100vh - 475px)`. `475` is the sum of both the height of the header(100px) and that of the footer(375px).

## Pages/Interfaces that will change
All pages in the website will be affected since they are children of the `main` tag. 
### Screenshots / video of changes
- Before
![image](https://user-images.githubusercontent.com/39762577/85435696-85a01380-b590-11ea-9e2f-942f29847e6d.png)
- After
![image](https://user-images.githubusercontent.com/39762577/85435840-bf711a00-b590-11ea-96d3-b8f997710949.png)

## Steps to test

1. Go to `allies` page
2. Make sure that you haven't accepted the terms and conditions. If you did, then open the chrome developer tools, go to application tab, and in `LocaleStorage` go to the website domain. In case of development, it is usually `http://localhost:8000`. 
3. Delete the `acceptedTAC` item and refresh the page. You should now see the modal with the whitespace block fixed.