### PR TITLE
Update README API Documentation link location

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Upon clicking the above link, you will get "Read Only" access to the database.
 
 Once you've obtained access, go to the API docs and grab your API key by visiting the following link: https://airtable.com/appFoFzjMcciPUgoK/api/docs#javascript/authentication
 
-Or by clicking on your user image in Airtable, and finding the "API Documentation" link:
+Or by clicking on HELP button in the upper right hand corner of Airtable, and finding the "API Documentation" link:
 
 ![Airtable API documentation link](docs/images/airtable-api-key-api-documentation.png)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This site uses Airtable to keep track of business data. We have set up a dummy d
 
 Upon clicking the above link, you will get "Read Only" access to the database.
 
-Once you've obtained access, go to the API docs and grab your API key clicking on HELP button in the upper right hand corner Airtable, and clicking the "API Documentation" link. 
+Once you've obtained access, grab your API key clicking on HELP button in the upper right hand corner Airtable, and clicking the "API Documentation" link. 
 
 ![Airtable API documentation link](docs/images/airtable-api-key-api-documentation.png)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This site uses Airtable to keep track of business data. We have set up a dummy d
 
 Upon clicking the above link, you will get "Read Only" access to the database.
 
-Once you've obtained access, go to the API docs and grab your API key clicking on HELP button in the upper right hand corner Airtable, and finding the "API Documentation" link. 
+Once you've obtained access, go to the API docs and grab your API key clicking on HELP button in the upper right hand corner Airtable, and clicking the "API Documentation" link. 
 
 ![Airtable API documentation link](docs/images/airtable-api-key-api-documentation.png)
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ This site uses Airtable to keep track of business data. We have set up a dummy d
 
 Upon clicking the above link, you will get "Read Only" access to the database.
 
-Once you've obtained access, go to the API docs and grab your API key by visiting the following link: https://airtable.com/appFoFzjMcciPUgoK/api/docs#javascript/authentication
-
-Or by clicking on HELP button in the upper right hand corner of Airtable, and finding the "API Documentation" link:
+Once you've obtained access, go to the API docs and grab your API key clicking on HELP button in the upper right hand corner Airtable, and finding the "API Documentation" link. 
 
 ![Airtable API documentation link](docs/images/airtable-api-key-api-documentation.png)
 


### PR DESCRIPTION
The API Documentation link is under the help button not the user image.

## Pages/Interfaces that will change

README section for AirTable test DB setup

### Additional notes

The https://airtable.com/appFoFzjMcciPUgoK/api/docs#javascript/authentication link referenced above this change may also have changed or be user specific because it 404s. Didn't want to update it if that link was role-specific (mine is https://airtable.com/appkenjGlBB01wr3i/api/docs#javascript/authentication). My dummy DB is **TEST DATA :: RBB :: TEST DATA**.

re: 
![image](https://user-images.githubusercontent.com/3998604/85492565-5e067680-b5a3-11ea-9c45-085798816ef7.png)
