### PR TITLE
Add skeleton loaders in businesses page

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -20,6 +20,7 @@ function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
     <Box
       maxW={theme.containers.main}
       paddingX={[null, theme.spacing.base, theme.spacing.lg]}
+      width="100%"
     >
       <BusinessFilter
         onSearch={filters => onSearch(filters)}
@@ -29,8 +30,16 @@ function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
       {(searching || initialLoad) && (
         <Box mb={10}>
           <SimpleGrid columns={[null, 1, 2]} spacing={10}>
-            {[...Array.from(new Array(4))].map((val, index) => (
-              <Skeleton key={index} height="300px" />
+            {[...Array.from(new Array(20))].map((_, index) => (
+              <Skeleton key={index}>
+                <ResultCard
+                  category={{ id: 1, name: 'Entertainment' }}
+                  name="Saving Small Businesses In Chicago- Skyway Bowl"
+                  description="PlaceHolder Description"
+                  location="Placeholder Location"
+                  donationUrl="Placeholder Url"
+                />
+              </Skeleton>
             ))}
           </SimpleGrid>
         </Box>

--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -1,4 +1,4 @@
-import { Box, SimpleGrid, useTheme } from '@chakra-ui/core';
+import { Box, SimpleGrid, useTheme, Skeleton } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import NoResultsCard from '../Cards/NoResultsCard';
@@ -12,6 +12,8 @@ function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
 
   const loaded = loadingState === LOADING_STATE.NONE;
   const initialLoad = loadingState === LOADING_STATE.INITIAL;
+  const searching = loadingState === LOADING_STATE.SEARCHING;
+
   const hasResults = businesses.length > 0;
 
   return (
@@ -24,7 +26,17 @@ function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
         selectedFilters={selectedFilters}
         isSearching={loadingState === LOADING_STATE.SEARCHING}
       />
-      {!initialLoad && hasResults && (
+      {(searching || initialLoad) && (
+        <Box mb={10}>
+          <SimpleGrid columns={[null, 1, 2]} spacing={10}>
+            {[...Array.from(new Array(4))].map((val, index) => (
+              <Skeleton key={index} height="300px" />
+            ))}
+          </SimpleGrid>
+        </Box>
+      )}
+
+      {!initialLoad && hasResults && !searching && (
         <>
           <SimpleGrid columns={[null, 1, 2]} spacing={10}>
             {businesses.map(business => {
@@ -33,7 +45,7 @@ function BusinessFeed({ businesses, onSearch, selectedFilters, loadingState }) {
               }${business.state ? business.state : ''}`;
               return (
                 <ResultCard
-                  key={business.objectID}
+                  key={business.id}
                   name={business.businessName || business.name}
                   category={business.category}
                   description={business.description}

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -114,6 +114,8 @@ export default function Businesses(props) {
     page
   );
 
+  const searching = loadingState === LOADING_STATE.SEARCHING;
+
   function onSearch(filters) {
     setLoadingState(LOADING_STATE.SEARCHING);
     generateURL(filters, setPageLocation);
@@ -178,7 +180,7 @@ export default function Businesses(props) {
           loadingState={loadingState}
         />
 
-        {!!results.length && (
+        {!!results.length && !searching && (
           <Pagination
             location={pageLocation}
             currentPage={parseInt(page)}


### PR DESCRIPTION
# Describe your PR
Add skeleton loaders in businesses page on initial page load and also while searching. Moreover, hide pagination while searching in businesses page.


## Pages/Interfaces that will change
The businesses page will be affected by this change.
### Screenshots / video of changes
- Before
https://www.loom.com/share/3ce5fb01db49464b800fbc52103cdc4f
- After
https://www.loom.com/share/51c0800875fc485883c3b7982e938106


## Steps to test

1. Go to `/businesses` page and refresh. You should see the skeleton loaders appearing before getting back the results.
2. Click on the search button to see the skeleton loaders appear while searching.
