### PR TITLE
Added padding left to the Tablet breakpoint

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -69,7 +69,7 @@ export default () => {
           backgroundColor="#000"
           backgroundMode="fade"
         >
-          <Box pt={16} pb={[72, 72, 145]} color="white">
+          <Box pt={16} pb={[72, 72, 145]} pl={[0, 0, 'inherit']} color="white">
             <Heading mb={theme.spacing.lg} as="h1">
               <Text
                 lineHeight="0.5"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -69,7 +69,7 @@ export default () => {
           backgroundColor="#000"
           backgroundMode="fade"
         >
-          <Box pt={16} pb={[72, 72, 145]} pl={[0, 0, 'inherit']} color="white">
+          <Box pt={16} pb={[72, 72, 145]} ml={[0, 0, 10]} color="white">
             <Heading mb={theme.spacing.lg} as="h1">
               <Text
                 lineHeight="0.5"


### PR DESCRIPTION
# Describe your PR

I added a Padding Left property to the Box component in order to fix the Heading being on the very edge for iPad/Tablet

## Pages/Interfaces that will change
The Index page

### Screenshots / video of changes

Before:  ![Screen Shot 2020-06-26 at 8 07 19 AM](https://user-images.githubusercontent.com/46144954/85872026-14c14d00-b784-11ea-8a1d-a408ab49048a.png)

After: ![Screen Shot 2020-06-26 at 8 08 02 AM](https://user-images.githubusercontent.com/46144954/85872123-2dc9fe00-b784-11ea-948f-1d3b580894b0.png)

## Steps to test

1. Switched between all breakpoints and different devices to check the spacing change
2.) Verified in the Dev Tools that the change was applied to the appropriate breakpoint
