### PR TITLE
feat: added source tracking (utm) parameters to external business url…

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-use": "^15.2.2",
     "typeface-arvo": "^1.1.3",
     "typeface-inter": "^3.12.0",
-    "url-parse": "^1.4.7",
     "use-cloudinary": "^2.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-use": "^15.2.2",
     "typeface-arvo": "^1.1.3",
     "typeface-inter": "^3.12.0",
+    "url-parse": "^1.4.7",
     "use-cloudinary": "^2.2.5"
   },
   "devDependencies": {

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -16,7 +16,7 @@ function setUrlUtm(link) {
 
   if (
     // Ensure that the link is external and follows http protocol (as opposed to mailto)
-    url.hostname !== window.location.hostname &&
+    !url.hostname.includes('rebuildblackbusiness.com') &&
     url.protocol.includes('http')
   ) {
     const query = url.query;

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -8,8 +8,30 @@ import {
   Text,
   Stack,
 } from '@chakra-ui/core';
-
+import URL from 'url-parse';
 import { Button, Image } from '.';
+
+function setUrlUtm(link) {
+  let url = new URL(link);
+
+  if (
+    // Ensure that the link is external and follows http protocol (as opposed to mailto)
+    url.hostname !== window.location.hostname &&
+    url.protocol.includes('http')
+  ) {
+    const query = url.query;
+
+    if (!query.includes('?')) {
+      // Set the one and only query
+      url.set('query', { utm_source: 'Rebuild+Black+Business' }, false);
+    } else if (!query.includes('utm_source')) {
+      // Append if there are multiple queries and no utm_source
+      url.set('query', url.query + '&utm_source=Rebuild+Black+Business', false);
+    }
+  }
+
+  return url.href;
+}
 
 const CardWrapper = forwardRef(({ children, ...props }, ref) => {
   return (
@@ -91,6 +113,8 @@ const CardButtonGroup = forwardRef(({ children, ...props }, ref) => {
 });
 
 const CardButton = forwardRef(({ children, ...props }, ref) => {
+  props.href = setUrlUtm(props.href);
+
   return (
     <Button flexGrow={1} variant="primary" {...props} ref={ref}>
       {children}

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -8,30 +8,8 @@ import {
   Text,
   Stack,
 } from '@chakra-ui/core';
-import URL from 'url-parse';
+import { setUrlUtm } from '../utils/urlUtils';
 import { Button, Image } from '.';
-
-function setUrlUtm(link) {
-  let url = new URL(link);
-
-  if (
-    // Ensure that the link is external and follows http protocol (as opposed to mailto)
-    !url.hostname.includes('rebuildblackbusiness.com') &&
-    url.protocol.includes('http')
-  ) {
-    const query = url.query;
-
-    if (!query.includes('?')) {
-      // Set the one and only query
-      url.set('query', { utm_source: 'Rebuild+Black+Business' }, false);
-    } else if (!query.includes('utm_source')) {
-      // Append if there are multiple queries and no utm_source
-      url.set('query', url.query + '&utm_source=Rebuild+Black+Business', false);
-    }
-  }
-
-  return url.href;
-}
 
 const CardWrapper = forwardRef(({ children, ...props }, ref) => {
   return (

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -1,0 +1,24 @@
+export const setUrlUtm = url => {
+  if (
+    // Ensure that the link is external and follows http protocol (as opposed to mailto)
+    !url.includes('rebuildblackbusiness.com') &&
+    url.includes('http')
+  ) {
+    url = new URL('', url);
+
+    if (!url.search) {
+      // Set the one and only query
+      url += '?utm_source=Rebuild+Black+Business';
+    } else if (!url.search?.includes('utm_source')) {
+      // Append if there are multiple queries and no utm_source
+      const urlString = url.toString();
+      const index = urlString.indexOf('?') + 1;
+      url =
+        urlString.slice(0, index) +
+        'utm_source=Rebuild+Black+Business&' +
+        urlString.slice(index);
+    }
+  }
+
+  return url.toString();
+};


### PR DESCRIPTION
# Describe your PR

Dynamically adds utm source tracking queries to external business urls

Related to #280 

## Pages/Interfaces that will change

- /businesses ResultCards

### Screenshots / video of changes

![RBB-PR-UTM](https://user-images.githubusercontent.com/39858613/85961732-75b27600-b97a-11ea-9e20-d12338bc2bde.png)

## Steps to test

1. Visit /businesses
2. Hover over or click on external links on ResultCards (Learn More, Donate)
3. Look at link preview or address bar 
    utm_source query will be set to "Rebuild+Black+Business" if one is not already given

### Additional notes

Works regardless of whether or not the url already has queries, and does not overwrite already established utm_source attributes. 

Links are verified to be external and use http/s protocol (i.e. no mailto links) before editing.