### PR TITLE
show skeleton loaders in businesses when page number changes

### DIFF
--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 
 import {
   Flex,
@@ -91,6 +91,11 @@ export default function Businesses(props) {
     coordinates: {},
   });
   const theme = useTheme();
+  const { page } = usePagination(pageLocation);
+  const { results, totalPages, loadingState, setLoadingState } = useSearch(
+    searchFilters,
+    page
+  );
 
   // Do this before we start searching and paginating
   useEffect(() => {
@@ -108,11 +113,15 @@ export default function Businesses(props) {
     setLocationCoordinatesFromURL();
   }, [props.location]);
 
-  const { page } = usePagination(pageLocation);
-  const { results, totalPages, loadingState, setLoadingState } = useSearch(
-    searchFilters,
-    page
-  );
+  // useLayoutEffect will make sure the skeleton loaders appear immediately when the page location changes
+  // using useEffect will also work but it will show a flash of ResultCards before showing the skeleton loaders
+  useLayoutEffect(() => {
+    setLoadingState(currLoadingState =>
+      currLoadingState === LOADING_STATE.INITIAL
+        ? currLoadingState
+        : LOADING_STATE.SEARCHING
+    );
+  }, [props.location, setLoadingState]);
 
   const searching = loadingState === LOADING_STATE.SEARCHING;
 


### PR DESCRIPTION
# Describe your PR
Change loading state to `loading` when the page number changes. This will make sure that skeleton loaders appear in the `/businesses` page when changing pages.
Related to #293 
Fixes #293 

## Pages/Interfaces that will change
The `/businesses` page will be affected.
### Screenshots / video of changes
- Before
https://www.loom.com/share/cd89a04656e64a149eacfc9b6791ee2c

- After
https://www.loom.com/share/1026e7ed54654513b7a01d32fc4cf265

## Steps to test

1. Go to `/businesses` page
2. Scroll down to bottom of the page
3. Click on any page number
4. You should see the skeleton loaders appear

