### PR TITLE
Upgraded use-cloudinary to v3 and updated hook usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3392,11 +3392,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@scarf/scarf": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.6.tgz",
-      "integrity": "sha512-y4+DuXrAd1W5UIY3zTcsosi/1GyYT8k5jGnZ/wG7UUHVrU+MHlH4Mp87KK2/lvMW4+H7HVcdB+aJhqywgXksjA=="
-    },
     "@sentry/browser": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.17.0.tgz",
@@ -6551,9 +6546,9 @@
       }
     },
     "cloudinary-core": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.8.2.tgz",
-      "integrity": "sha512-nV1lhEXlqNhgnbnzsDzbrNUAkP8H9J5RuBareRlWyb8tKx/94DvG/kXWrSlC8XNB3uKfiwxOudOnRdjsEnjBgA=="
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.10.1.tgz",
+      "integrity": "sha512-eRKZq1irjRRjrqXu8DCFJ5bEYJh9NUuXpEzPQ2u2fdc8NXsk+WlioMrlEpwTD1PF23OPnen45mw4B04Dzw5ydg=="
     },
     "co": {
       "version": "4.6.0",
@@ -20072,12 +20067,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-query": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-1.5.7.tgz",
-      "integrity": "sha512-VyX3CwfRtEIQN5Y34cOX8cIx6pKsJMKlFrfCtGfbBDLbmqgMQctc9i84W7FjI+eXcDQ/BMIASccyp5D88N9znw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-2.4.13.tgz",
+      "integrity": "sha512-PFUmChSy3kph+r0c+oz7HgBiKi98bb1D8FeeBZ1qiuuGXUJYhWCvOST+lOgwtLiBbT1wdoNjObFC35jpHbSvUQ==",
       "requires": {
-        "@scarf/scarf": "^1.0.0",
-        "ts-toolbelt": "^6.4.2"
+        "ts-toolbelt": "^6.9.4"
       }
     },
     "react-reconciler": {
@@ -23094,9 +23088,9 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
     },
     "ts-toolbelt": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.9.4.tgz",
-      "integrity": "sha512-muRZZqfOTOVvLk5cdnp7YWm6xX+kD/WL2cS/L4zximBRcbQSuMoTbQQ2ZZBVMs1gB0EZw1qThP+HrIQB35OmEw=="
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.9.9.tgz",
+      "integrity": "sha512-5a8k6qfbrL54N4Dw+i7M6kldrbjgDWb5Vit8DnT+gwThhvqMg8KtxLE5Vmnft+geIgaSOfNJyAcnmmlflS+Vdg=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",
@@ -23792,15 +23786,15 @@
       "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
     },
     "use-cloudinary": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/use-cloudinary/-/use-cloudinary-2.2.5.tgz",
-      "integrity": "sha512-ZVIo8MDGuq4znBqbwC4GzSipV/NbG2kNfjgzGJrm9S2pJu67knqPLmPpRSiW8kOFguMPlrnqZJrIWiqLN/rreQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/use-cloudinary/-/use-cloudinary-3.0.2.tgz",
+      "integrity": "sha512-Td5IkFzbWfFFiKSLtDor99Ktou6qZnBNEEuDNww0IRhOYcfMxRi5mu+cPth8o4Nx2vk0pd0uRb5FRz2UKo0g6w==",
       "requires": {
         "@babel/runtime": "^7.9.2",
         "cloudinary-core": "^2.8.2",
         "isomorphic-unfetch": "^3.0.0",
         "lodash": "^4.17.15",
-        "react-query": "^1.2.1"
+        "react-query": "^2.0.0"
       }
     },
     "use-dark-mode": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-use": "^15.2.2",
     "typeface-arvo": "^1.1.3",
     "typeface-inter": "^3.12.0",
-    "use-cloudinary": "^2.2.5"
+    "use-cloudinary": "^3.0.1"
   },
   "devDependencies": {
     "@testing-library/cypress": "^6.0.0",

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -6,20 +6,20 @@ import ImageSkeleton from './Loading/ImageSkeleton';
 export default function Image(props) {
   const { transforms, publicId, alt, src } = props;
 
-  const { getImage, data, status, error } = useImage({
-    cloud_name: 'rebuild-black-business',
+  const { generateUrl, url, status, error } = useImage({
+    cloudName: 'rebuild-black-business',
   });
 
   /* eslint-disable react-hooks/exhaustive-deps */
   React.useEffect(() => {
-    getImage({
-      public_id: publicId,
-      transform_options: {
+    generateUrl({
+      publicId,
+      transformations: {
         ...transforms,
+        dpr: 2,
         // fetch: 'auto' is applied internally
         // crop: 'scale' is applied automatically when a width or height is supplied
-        quality: 'auto',
-        dpr: 2,
+        // quality: 'auto' is applied automatically
       },
     });
   }, [publicId]);
@@ -30,5 +30,5 @@ export default function Image(props) {
   // @TODO :: Deliver custom Error UI if needed
   if (status === 'error') return <p>{error.message}</p>;
 
-  return <ChakraImage {...props} src={data || src} alt={alt} />;
+  return <ChakraImage {...props} src={url || src} alt={alt} />;
 }


### PR DESCRIPTION
# Describe your PR
I recently released v3 of the `use-cloudinary` hooks and wanted to make an upgrade here.

More base config has been added to our image calls. I updated some API nomenclature as well. 

Will be circling back and adding lazy-loading from the hook as well in another PR (after the upgrade is in the lib)


## Steps to test

1. Make sure all images load the same as they were before throughout the app 

