### PR TITLE
fix: white flash of before image load

### DIFF
--- a/src/components/ContentBlock.js
+++ b/src/components/ContentBlock.js
@@ -24,6 +24,7 @@ const ContentBlockContent = props => {
       h="100%"
       w="100%"
       px={[4, 4, 8]}
+      zIndex={1}
       {...props}
     >
       {props.children}
@@ -45,7 +46,6 @@ const ContentBlockColorOverlay = ({
       left="0"
       opacity={backgroundOpacity}
       backgroundColor={backgroundColor}
-      zIndex="-1"
       {...props}
     />
   );
@@ -96,6 +96,7 @@ const LeftSideContentBlock = ({
     return (
       <ContentBlockWrapper
         imageSource={imageSource}
+        backgroundColor={backgroundColor}
         textAlign={['center', 'center', 'left']}
         right="0"
       >
@@ -112,7 +113,6 @@ const LeftSideContentBlock = ({
           right="0"
           w={['100%', '100%', '52%']}
           height="100%"
-          zIndex="-1"
         />
         <ContentBlockColorOverlay
           backgroundColor={backgroundColor}
@@ -130,6 +130,7 @@ const LeftSideContentBlock = ({
         imageWidth={['100%', '100%', '55%']}
         imagePosition={{ right: 0 }}
         textAlign={['center', 'center', 'left']}
+        backgroundColor={backgroundColor}
       >
         <Image
           publicId={imageSource}
@@ -144,7 +145,6 @@ const LeftSideContentBlock = ({
           right="0"
           w={['100%', '100%', '52%']}
           height="100%"
-          zIndex="-1"
         />
         <ContentBlockColorOverlay
           backgroundMode={backgroundMode}
@@ -202,7 +202,6 @@ const RightSideContentBlock = ({
           left="0"
           w={['100%', '100%', '52%']}
           height="100%"
-          zIndex="-1"
         />
         <ContentBlockColorOverlay
           backgroundColor={backgroundColor}
@@ -232,7 +231,6 @@ const RightSideContentBlock = ({
           left="0"
           w={['100%', '100%', '52%']}
           height="100%"
-          zIndex="-1"
         />
         <ContentBlockColorOverlay
           backgroundMode={backgroundMode}
@@ -274,7 +272,6 @@ const FullWidthContentBlock = ({
         left="0"
         w="100%"
         height="100%"
-        zIndex="-1"
       />
       <ContentBlockColorOverlay
         backgroundColor={backgroundColor}


### PR DESCRIPTION
This doesn't fix the overall problem but allows the background color
to show before the image comes in. This sets the background color
on ContentBlock. The z-index setting is also inverted to push
ContentBlockColorOverlay and ContentBlockContent on top of image
instead of pushing the image underneath.

# Describe your PR

Related to #281 


## Pages/Interfaces that will change

- Homepage, About

### Screenshots / video of changes

https://www.loom.com/share/a8cfec7efd854fa1b13462c6f10910fb
#281 has a video of the current loading 

## Steps to test

1. Load homepage and watch hero load in with black background instead of white.

### Additional notes

Doesn't fix completely just softens image entry, more work coming around load issues for #281 