### PR TITLE
Fix: Changed z-index of navigation to bring it to forefront

### DIFF
--- a/src/components/PrimaryNav.js
+++ b/src/components/PrimaryNav.js
@@ -79,7 +79,7 @@ const PrimaryNav = forwardRef(
           ></Box>
         ) : null}
         <Nav
-          zIndex={1}
+          zIndex={2}
           position="absolute"
           width="100%"
           height={NAV_HEIGHT}


### PR DESCRIPTION
# Describe your PR

Page title and navigation were on the same z-index. Bumping the z-index of the navigation up by one resolves the issue and no further problematic interactions can be found

Fixes #304 

## Pages/Interfaces that will change

All pages with navigation on small (mobile) displays

### Screenshots / video of changes

![RBB-MobileNav](https://user-images.githubusercontent.com/39858613/87841323-929fe200-c872-11ea-978c-0ed93c319014.png)

## Steps to test

1. Open on a phone (or in the dev tools device emulator)
2.) Click on hamburger menu icon
