### PR TITLE
Add x-api-key to search call

### DIFF
--- a/.env.EXAMPLE
+++ b/.env.EXAMPLE
@@ -10,3 +10,9 @@
 GATSBY_AIRTABLE_API_KEY=
 # The AIRTABLE_BASE_ID below refers to the DUMMY DATABASE. Access to the production database must be requested.
 GATSBY_AIRTABLE_BASE_ID=appkenjGlBB01wr3i 
+
+
+# The GATSBY_RBB_API_KEY is stored in a note in the 1pass vault for this project.
+# Make sure you're using the appropriate key for the environment you're testing (production, staging, local dev)
+# Note: if you're testing locally, you should PROBABLY be looking at .env.development instead of here!
+GATSBY_RBB_API_KEY=12345

--- a/.env.development.EXAMPLE
+++ b/.env.development.EXAMPLE
@@ -1,1 +1,8 @@
+# copy/paste this file, and rename it to `.env.devlopment` (remove .EXAMPLE) - these are picked up by gatsby during local dev
+
 GATSBY_SEARCH_API_ENDPOINT=''
+
+# The GATSBY_RBB_API_KEY is stored in a note in the 1pass vault for this project.
+# Make sure you're using the appropriate key for the environment you're testing (production, staging, local dev)
+# Note: this file is only used in local development
+GATSBY_RBB_API_KEY=12345

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -45,7 +45,12 @@ function useSearch(filters, page) {
       try {
         const filterStr = createFilterString(defaultFilters, filters);
         const response = await fetch(
-          `${endpoint}api/v1/businesses?page=${page}&${filterStr}`
+          `${endpoint}api/v1/businesses?page=${page}&${filterStr}`,
+          {
+            headers: {
+              'x-api-key': process.env.GATSBY_RBB_API_KEY,
+            },
+          }
         );
         const results = await response.json();
 


### PR DESCRIPTION
# Describe your PR
This PR adds an `x-api-key` parameter to our calls to the search endpoint

Fixes #311 

## Pages/Interfaces that will change
/businesses search page

### Screenshots / video of changes
This will appear in the network tab of your browser dev tools when you execute a search (highlighted here).  I'll need confirmation from @elchris that this is what we're looking for, since the API changes aren't deployed yet. 
![image](https://user-images.githubusercontent.com/1844496/88488813-c9a28180-cf5d-11ea-8633-5ff948435069.png)



## Steps to test

1. @elchris help! :) 

### Additional notes
- [x] Q: do we make any other API calls to our own endpoints? I couldn't find any.
- [ ] I'd like to implement react-query to better cache search calls on the front end at some point (that should maybe be broken out into its own issue?)
