### PR TITLE
adjust business listing grid

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -25,7 +25,7 @@ function BusinessFeed({
 
   return (
     <Box
-      maxW={theme.containers.main}
+      maxW={theme.containers.lg}
       paddingX={[null, theme.spacing.base, theme.spacing.lg]}
       width="100%"
     >
@@ -36,7 +36,7 @@ function BusinessFeed({
       />
       {(searching || initialLoad) && (
         <Box mb={10}>
-          <SimpleGrid columns={[null, 1, 2]} spacing={10}>
+          <SimpleGrid columns={[null, 1, 2, 3, 4]} spacing={10}>
             {[...Array.from(new Array(20))].map((_, index) => (
               <Skeleton key={index}>
                 <ResultCard
@@ -54,7 +54,7 @@ function BusinessFeed({
 
       {!initialLoad && hasResults && !searching && (
         <>
-          <SimpleGrid columns={[null, 1, 2]} spacing={10}>
+          <SimpleGrid columns={[null, 1, 2, 3, 4]} spacing={10}>
             {businesses.map((business, index) => {
               const formattedLocation = `${business.city ? business.city : ''}${
                 business.city && business.state ? ', ' : ''

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -143,7 +143,13 @@ const ResultCard = forwardRef(
           bg={theme.colors['rbb-result-card-grey']}
           color={hasImage ? undefined : theme.colors['rbb-black-200']}
         >
-          <Heading as="h2" itemprop="name" size="md" fontWeight="normal">
+          <Heading
+            as="h2"
+            itemprop="name"
+            size="md"
+            fontWeight="normal"
+            wordBreak="break-all"
+          >
             {name}
           </Heading>
           {category && (

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -149,6 +149,7 @@ const ResultCard = forwardRef(
             size="md"
             fontWeight="normal"
             wordBreak="break-all"
+            style={{ hyphens: 'auto' }}
           >
             {name}
           </Heading>

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -177,10 +177,13 @@ const ResultCard = forwardRef(
               {location}
             </CardText>
           )}
+          {/* TODO: spacing={0} and wrap="wrap" are added temporarily.  Fix this and replace it with <Wrap/> component in newer Chakra-UI version */}
           <CardButtonGroup
             mt="auto"
             mb={theme.spacing.base}
             pt={theme.spacing.base}
+            spacing={0}
+            wrap="wrap"
           >
             {websiteUrl && (
               <CardButton

--- a/src/gatsby-plugin-chakra-ui/theme.js
+++ b/src/gatsby-plugin-chakra-ui/theme.js
@@ -7,7 +7,7 @@ const customTheme = {
   ...theme,
   containers: {
     main: '1220px',
-    lg: '1516px',
+    lg: '1600px',
   },
   spacing: {
     xs: '0.75rem',

--- a/src/gatsby-plugin-chakra-ui/theme.js
+++ b/src/gatsby-plugin-chakra-ui/theme.js
@@ -7,6 +7,7 @@ const customTheme = {
   ...theme,
   containers: {
     main: '1220px',
+    lg: '1516px',
   },
   spacing: {
     xs: '0.75rem',

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -7,7 +7,7 @@ const LOADING_STATE = {
   INITIAL: 'intial',
   SEARCHING: 'searching',
 };
-const pageSize = 19;
+const pageSize = 11;
 
 function createFilterString(defaultFilters = '', filters) {
   const filterArr = [];


### PR DESCRIPTION
# Describe your PR

Adjust businesses listing grid to show 12 listings on the page, where each row has between 1 and 4 listings.

Related to #313 

## Pages/Interfaces that will change
`/businesses` page will be affected

### Screenshots / video of changes
1. 4 listings per row
![image](https://user-images.githubusercontent.com/39762577/89207027-bed19780-d5c2-11ea-8b83-258a54c7b678.png)

2. 3 listings per row
![image](https://user-images.githubusercontent.com/39762577/89207070-dad53900-d5c2-11ea-8b43-d46a12dda3c0.png)

3. 2 listings per row
![image](https://user-images.githubusercontent.com/39762577/89207113-ec1e4580-d5c2-11ea-8d4d-99726b886921.png)

4. 1 listing per row
![image](https://user-images.githubusercontent.com/39762577/89207160-fdffe880-d5c2-11ea-9ee9-1aabf91e5c70.png)

## Steps to test

1. Go to `/businesses` page.
2. Resize window