### PR TITLE
fixed #325 text-wrap-bug

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -148,8 +148,9 @@ const ResultCard = forwardRef(
             itemprop="name"
             size="md"
             fontWeight="normal"
-            wordBreak="break-all"
-            style={{ hyphens: 'auto' }}
+            wordBreak="break-word"
+            overflowWrap="break-word"
+            fontFamily={theme.fonts['heading-slab']}
           >
             {name}
           </Heading>


### PR DESCRIPTION
# Describe your PR
Previously the text wrap split continuous words into half, Mike and I changed this feature to split new words into new lines.
Related to #
Fixes #325

## Pages/Interfaces that will change
/businesses & /fundraisers

### Screenshots / video of changes
<img width="304" alt="Screen Shot 2020-08-29 at 1 48 38 PM" src="https://user-images.githubusercontent.com/9298105/91643114-7610d100-e9fe-11ea-9632-c5488c3416cb.png">
<img width="303" alt="Screen Shot 2020-08-29 at 12 18 34 PM" src="https://user-images.githubusercontent.com/9298105/91643116-78732b00-e9fe-11ea-8272-c74c8921f584.png">

Drop some screenshots of the before and after of your work here. Better yet, take a screen recording using a tool like [Loom](https://www.loom.com/)

## Steps to test

1.load /businesses or /fundraisers

### Additional notes
Thanks a lot to Mike Bifulco!