### PR TITLE
Feature/smooth scroll to ID

### DIFF
--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -1,12 +1,13 @@
 import { Box, SimpleGrid, useTheme, Skeleton } from '@chakra-ui/core';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import NoResultsCard from '../Cards/NoResultsCard';
 import BusinessFilter from '../Filters/BusinessFilter';
 import { LOADING_STATE } from '../../hooks/useSearch';
 import ResultCard from '../ResultCard';
 import { verifyHttpUrl } from '../../utils/urlUtils';
 import RegistrationPromo from '../Promos/RegistrationPromo';
+import { scrollToId } from '../../utils/scrollToId';
 
 function BusinessFeed({
   businesses,
@@ -22,6 +23,14 @@ function BusinessFeed({
   const searching = loadingState === LOADING_STATE.SEARCHING;
 
   const hasResults = businesses.length > 0;
+
+  useEffect(() => {
+    if (window && window.location.hash) {
+      window.setTimeout(() => {
+        scrollToId(window.location.hash);
+      }, 200);
+    }
+  }, [loaded]);
 
   return (
     <Box
@@ -54,7 +63,7 @@ function BusinessFeed({
 
       {!initialLoad && hasResults && !searching && (
         <>
-          <SimpleGrid columns={[null, 1, 2, 3, 4]} spacing={10}>
+          <SimpleGrid id="results" columns={[null, 1, 2, 3, 4]} spacing={10}>
             {businesses.map((business, index) => {
               const formattedLocation = `${business.city ? business.city : ''}${
                 business.city && business.state ? ', ' : ''

--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -134,7 +134,7 @@ function Pagination({ location, currentPage, totalPages }) {
     const params = getUpdatedSearchParams(location.search, { page });
 
     if (params) {
-      return `${pathname}?${params}`;
+      return `${pathname}?${params}#results`;
     }
 
     return pathname;

--- a/src/pages/legal.js
+++ b/src/pages/legal.js
@@ -1,8 +1,9 @@
 import { Box, Flex, Heading } from '@chakra-ui/core';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '../components/Layout';
 import Privacy from '../docs/privacy-policy';
 import Terms from '../docs/terms-and-conditions';
+import { scrollToId } from '../utils/scrollToId';
 
 export default function About() {
   const legalData = [
@@ -17,6 +18,13 @@ export default function About() {
       body: <Privacy />,
     },
   ];
+
+  useEffect(() => {
+    if (window && window.location.hash) {
+      scrollToId(window.location.hash);
+    }
+  }, []);
+
   return (
     <Layout p="4">
       <Flex justify="center" direction="column" align="center">

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -46,7 +46,7 @@ function generateURL(filters, setPageLocation) {
   }
 
   if (filters.location) {
-    queryString += `?location=${filters.location}`;
+    queryString += `?location=${filters.location}#results`;
   }
 
   // Update the page location state so pagination works

--- a/src/utils/scrollToId.js
+++ b/src/utils/scrollToId.js
@@ -1,0 +1,11 @@
+export const scrollToId = id => {
+  const element = document.querySelector(id);
+  return (
+    element &&
+    window.scrollTo({
+      left: 0,
+      top: element.offsetTop - 20,
+      behavior: 'smooth',
+    })
+  );
+};


### PR DESCRIPTION
# Describe your PR

Note: This is https://github.com/Rebuild-Black-Business/RBB-Website/pull/239 after I resolved merge conflicts months later

Gatsby Links don't support scrolling to hash ids in the url natively so I implemented a quick fix that is in use on Business and Legal pages. Needed to wrap business load in a timeout for more consistent experience.

Related to https://trello.com/c/QfHWbLi8/207-navigating-to-another-page-of-search-results-should-bring-you-to-the-results-portion-of-the-page-not-the-top-of-the-page-skip-th

## Pages/Interfaces that will change
Legal & Business

### Screenshots / video of changes
https://www.loom.com/share/b0666dedf72d421db9046e69be0f3b48

## Steps to test

1. Go to business page and scroll down to pagination on the bottom.
2. Click a page other than the currently active page
3. -> Smooth scroll to results section of new page 

===========

1. Go to allies page gate
2. Click Terms and Conditions link
3. -> Smooth scroll to TaC
