### PR TITLE
Build time optimizations - shutting off type inference

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,3 +48,13 @@ exports.createPages = async ({ graphql, actions }) => {
     }
   });
 };
+
+// switch off type inference for SitePage.context
+// more info here - https://www.gatsbyjs.com/docs/scaling-issues/#switch-off-type-inference-for-sitepagecontext
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type SitePage implements Node @dontInfer {
+      path: String!
+    }
+  `);
+};


### PR DESCRIPTION
# Describe your PR
After some discussion with Jason Lengstorf from Netlify, I'm looking into a few different build-time optimizations.  One of the suggestions was to shut off type inference for page context within gatsby, which cuts down on calculations done for each page of the site (13k and growing as of this PR).

More info here: https://www.gatsbyjs.com/docs/scaling-issues/#switch-off-type-inference-for-sitepagecontext


Related to `perf`
Fixes `n/a`

## Pages/Interfaces that will change
netlify build time 🤞 

### Screenshots / video of changes
n/a

## Steps to test

1. run netlify build - hopefully it's faster!

### Additional notes
