### PR TITLE
Add shout out to Netlify to footer

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -4,6 +4,7 @@ import SocialLinks from './SocialLinks';
 import FooterLinks from './FooterLinks';
 import PhotoCredit from './PhotoCredits';
 import Copyright from './Copyright';
+import NetlifyThanks from './NetlifyThanks';
 
 const Footer = () => {
   const theme = useTheme();
@@ -28,6 +29,7 @@ const Footer = () => {
         <FooterLinks />
         <Flex direction="column">
           <PhotoCredit />
+          <NetlifyThanks />
           <Copyright />
         </Flex>
       </Flex>

--- a/src/components/footer/NetlifyThanks.js
+++ b/src/components/footer/NetlifyThanks.js
@@ -22,7 +22,7 @@ const NetlifyThanks = () => {
           color={theme.colors['rbb-white']}
           opacity={0.5}
         >
-          This site is powered by
+          This site is powered by{' '}
           <ExternalLink variant="footer" isExternal href="https://netlify.com">
             Netlify
           </ExternalLink>

--- a/src/components/footer/NetlifyThanks.js
+++ b/src/components/footer/NetlifyThanks.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Flex, Text, useTheme } from '@chakra-ui/core';
+
+import ExternalLink from '../ExternalLink';
+
+/*
+  Shout out to netlify for free build minutes for the OSS project.  More context here: 
+  https://www.netlify.com/legal/open-source-policy/
+*/
+const NetlifyThanks = () => {
+  const theme = useTheme();
+  return (
+    <Flex w="full" justify="center" align="center" mb={4}>
+      <Flex
+        w={['80%', '80%', '80%', 'full']}
+        justify="center"
+        textAlign="center"
+      >
+        <Text
+          fontSize="12px"
+          fontFamily={theme.fonts.heading}
+          color={theme.colors['rbb-white']}
+          opacity={0.5}
+        >
+          This site is powered by
+          <ExternalLink variant="footer" isExternal href="https://netlify.com">
+            Netlify
+          </ExternalLink>
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default NetlifyThanks;

--- a/src/components/footer/NetlifyThanks.js
+++ b/src/components/footer/NetlifyThanks.js
@@ -22,11 +22,20 @@ const NetlifyThanks = () => {
           color={theme.colors['rbb-white']}
           opacity={0.5}
         >
-          This site is powered by{' '}
-          <ExternalLink variant="footer" isExternal href="https://netlify.com">
-            Netlify
-          </ExternalLink>
+          This site is powered by
         </Text>
+        <ExternalLink
+          fontSize="12px"
+          fontWeight="bold"
+          ml="1"
+          mr="1"
+          color={theme.footer.photoCreditLink}
+          isExternal
+          variant="footer"
+          href="https://netlify.com"
+        >
+          Netlify
+        </ExternalLink>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
# Describe your PR
Turns out we're eligible for some free build minutes as a result of Netlify's generous [Open Source Program](https://www.netlify.com/legal/open-source-policy/).  One of the requirements is a shout out in our footer.  This adds that!

### Screenshots / video of changes
![image](https://user-images.githubusercontent.com/1844496/93835168-67f45000-fc4c-11ea-8965-05d0d1183e01.png)

### Additional notes
Thanks to Jason Lengstorf for the suggestion!
