### PR TITLE
Implement client side routing and data fetching for individual businesses 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,39 +15,47 @@ exports.onCreatePage = async ({ page, actions }) => {
   }
 };
 
-exports.createPages = async ({ graphql, actions }) => {
-  const result = await graphql(`
-    query {
-      businesses: allAirtableBusinesses {
-        nodes {
-          data {
-            Business_Name
-            Name
-          }
-          recordId
-        }
-      }
-    }
-  `);
-
-  result.data.businesses.nodes.forEach(business => {
-    const slug = getSlugForBusiness({
-      businessName: business.data.Business_Name,
-      name: business.data.Name,
-      airtableId: business.recordId,
-    });
-
-    if (slug) {
-      actions.createPage({
-        path: `/business/${slug}`,
-        component: require.resolve('./src/templates/singleBusinessPage'),
-        context: {
-          businessId: business.recordId,
-        },
-      });
-    }
+exports.createPages = ({ actions }) => {
+  actions.createPage({
+    path: `/business`,
+    matchPath: `/business/:id`,
+    component: require.resolve('./src/templates/singleBusinessPage'),
   });
 };
+
+// exports.createPages = async ({ graphql, actions }) => {
+//   const result = await graphql(`
+//     query {
+//       businesses: allAirtableBusinesses {
+//         nodes {
+//           data {
+//             Business_Name
+//             Name
+//           }
+//           recordId
+//         }
+//       }
+//     }
+//   `);
+
+//   result.data.businesses.nodes.forEach(business => {
+//     const slug = getSlugForBusiness({
+//       businessName: business.data.Business_Name,
+//       name: business.data.Name,
+//       airtableId: business.recordId,
+//     });
+
+//     if (slug) {
+//       actions.createPage({
+//         path: `/business/${slug}`,
+//         component: require.resolve('./src/templates/singleBusinessPage'),
+//         context: {
+//           businessId: business.recordId,
+//         },
+//       });
+//     }
+//   });
+// };
 
 // switch off type inference for SitePage.context
 // more info here - https://www.gatsbyjs.com/docs/scaling-issues/#switch-off-type-inference-for-sitepagecontext

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,3 @@
-const { getSlugForBusiness } = require('./src/utils/business');
-
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
 exports.onCreatePage = async ({ page, actions }) => {
@@ -22,40 +20,6 @@ exports.createPages = ({ actions }) => {
     component: require.resolve('./src/templates/singleBusinessPage'),
   });
 };
-
-// exports.createPages = async ({ graphql, actions }) => {
-//   const result = await graphql(`
-//     query {
-//       businesses: allAirtableBusinesses {
-//         nodes {
-//           data {
-//             Business_Name
-//             Name
-//           }
-//           recordId
-//         }
-//       }
-//     }
-//   `);
-
-//   result.data.businesses.nodes.forEach(business => {
-//     const slug = getSlugForBusiness({
-//       businessName: business.data.Business_Name,
-//       name: business.data.Name,
-//       airtableId: business.recordId,
-//     });
-
-//     if (slug) {
-//       actions.createPage({
-//         path: `/business/${slug}`,
-//         component: require.resolve('./src/templates/singleBusinessPage'),
-//         context: {
-//           businessId: business.recordId,
-//         },
-//       });
-//     }
-//   });
-// };
 
 // switch off type inference for SitePage.context
 // more info here - https://www.gatsbyjs.com/docs/scaling-issues/#switch-off-type-inference-for-sitepagecontext

--- a/src/components/Feeds/BusinessFeed.js
+++ b/src/components/Feeds/BusinessFeed.js
@@ -23,7 +23,6 @@ function BusinessFeed({
   const searching = loadingState === LOADING_STATE.SEARCHING;
 
   const hasResults = businesses.length > 0;
-
   useEffect(() => {
     if (window && window.location.hash) {
       window.setTimeout(() => {
@@ -76,6 +75,7 @@ function BusinessFeed({
                     key="registration-promo"
                   />,
                   <ResultCard
+                    id={business.id}
                     airTableId={business.airTableId}
                     key={business.id}
                     name={business.businessName || business.name}
@@ -89,6 +89,7 @@ function BusinessFeed({
               }
               return (
                 <ResultCard
+                  id={business.id}
                   airTableId={business.airTableId}
                   key={business.id}
                   name={business.businessName || business.name}

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -59,6 +59,7 @@ const ResultCard = forwardRef(
       location,
       websiteUrl,
       donationUrl,
+      id,
       ...props
     },
     ref
@@ -79,7 +80,7 @@ const ResultCard = forwardRef(
     const businessPageSlug = getSlugForBusiness({
       name: name,
       businessName: name,
-      airtableId: airTableId,
+      dbId: id,
     });
 
     const businessPageUrl = businessPageSlug

--- a/src/hooks/useBusinessDetails.js
+++ b/src/hooks/useBusinessDetails.js
@@ -5,7 +5,7 @@ const API_ENDPOINT = process.env.GATSBY_SEARCH_API_ENDPOINT;
 const API_KEY = process.env.GATSBY_RBB_API_KEY;
 
 const fetchBusiness = async (_, id) => {
-  const businessFetchUrl = `${API_ENDPOINT}private/api/v1/businesses/airtable/${id}?apiKey=${API_KEY}`;
+  const businessFetchUrl = `${API_ENDPOINT}api/v1/businesses/${id}?apiKey=${API_KEY}`;
 
   const { data } = await axios.get(businessFetchUrl);
 
@@ -15,5 +15,6 @@ const fetchBusiness = async (_, id) => {
 export const useBusinessDetails = airtableId => {
   return useQuery(['business-details', airtableId], fetchBusiness, {
     cacheTime: 1000 * 60 * 5, // cache results for up to 5 minutes
+    refetchOnWindowFocus: false,
   });
 };

--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -83,7 +83,7 @@ export default function Businesses(props) {
   const [pageLocation, setPageLocation] = useState(props.location);
   const [searchFilters, setSearchFilters] = useState({
     location: searchLocation(props.location),
-    need: searchingInNeed(props.location),
+    need: false,
     type: searchCategory(props.category),
     coordinates: {},
   });

--- a/src/templates/singleBusinessPage.js
+++ b/src/templates/singleBusinessPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { graphql } from 'gatsby';
 import copy from 'copy-to-clipboard';
 import { useToast } from '@chakra-ui/core';
 
@@ -23,19 +22,22 @@ import {
   SEO,
 } from '../components';
 import { Button } from '../components/Button';
-
 import { useImageForBusiness } from '../utils/business';
 import { useBusinessDetails } from '../hooks/useBusinessDetails';
 
-const SingleBusinessPage = ({ data, location, pageContext }) => {
+const SingleBusinessPage = ({ location, params }) => {
   const theme = useTheme();
+  const { id: businessSlug } = params;
+  const splitSlug = businessSlug && businessSlug.split('-');
+  const businessId = splitSlug.length > 0 && splitSlug[splitSlug.length - 1];
 
-  const business = data.airtableBusinesses.data;
+  const { data: apiResponse, isError } = useBusinessDetails(businessId);
+
   const {
     // name,
     approved,
     businessName,
-    businessDescription,
+    description: businessDescription,
     category,
     imageAlt, // TODO: these need to be populated in airtable?
     imageSrc, // TODO: these need to be populated in airtable?
@@ -45,21 +47,8 @@ const SingleBusinessPage = ({ data, location, pageContext }) => {
     // id,
     inNeed,
     // physicalLocation,
-    website,
+    site: website,
     // zipCode,
-  } = business;
-
-  const { hasImage, publicId, src, alt } = useImageForBusiness({
-    category,
-    imageAlt,
-    imageSrc,
-  });
-
-  const { data: apiResponse } = useBusinessDetails(pageContext.businessId);
-
-  const toast = useToast();
-
-  const {
     city,
     isAdult,
     isPhysicalLocation,
@@ -74,6 +63,14 @@ const SingleBusinessPage = ({ data, location, pageContext }) => {
     takesCredit,
     zip,
   } = apiResponse || {};
+
+  const { hasImage, publicId, src, alt } = useImageForBusiness({
+    category,
+    imageAlt,
+    imageSrc,
+  });
+
+  const toast = useToast();
 
   const shareClicked = event => {
     if (event && typeof event.preventDefault === 'function')
@@ -98,10 +95,41 @@ const SingleBusinessPage = ({ data, location, pageContext }) => {
   if (takesBitcoin) paymentTypes.push('bitcoin');
 
   // this page returns nothing if this is not an approved business
-  if (!approved) return null;
+  if (!approved && !isError) return <Layout>{null}</Layout>;
 
+  if (isError) {
+    return (
+      <Layout>
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          marginTop={['4rem', '4rem', 0, 0]}
+          marginBottom={['4rem', '4rem', 0, 0]}
+          textAlign={['center', 'center ', 'left ', 'left ']}
+          direction={['column', 'column', 'column', 'row']}
+        >
+          <Flex direction="column" maxW="335px">
+            <Text
+              as="h1"
+              fontFamily={theme.fonts['heading-slab']}
+              color={theme.colors['rbb-gray']}
+              mt={theme.spacing['med']}
+              fontWeight="900"
+              fontSize="64px"
+              lineHeight="77px"
+              textTransform="uppercase"
+              marginBottom="0.625rem"
+              textAlign="center"
+            >
+              BUSINESS NOT FOUND !
+            </Text>
+          </Flex>
+        </Flex>
+      </Layout>
+    );
+  }
   return (
-    <Layout background={theme.colors['rbb-white']}>
+    <Layout>
       <SEO title={businessName} description={businessDescription} />
       <Stack
         padding={`${theme.spacing.med} ${theme.spacing.base}`}
@@ -140,7 +168,7 @@ const SingleBusinessPage = ({ data, location, pageContext }) => {
                 {businessName}
               </Heading>
               <Text>
-                {category}
+                {category && category.name}
                 {isAdult && <Text as="span"> &bull; Adult (18+)</Text>}
               </Text>
             </div>
@@ -333,27 +361,5 @@ const SingleBusinessPage = ({ data, location, pageContext }) => {
     </Layout>
   );
 };
-
-export const query = graphql`
-  query SingleBusinessPageQuery($businessId: String) {
-    airtableBusinesses(recordId: { eq: $businessId }) {
-      data {
-        name: Name
-        approved: Approved
-        businessName: Business_Name
-        businessDescription: Business_Description
-        category: Category
-        createdAt: CreatedAt
-        donationLink: Donation_Link
-        email: Email
-        id: ID
-        inNeed: In_Need
-        physicalLocation: Physical_Location
-        website: Website
-        zipCode: Zip_Code
-      }
-    }
-  }
-`;
 
 export default SingleBusinessPage;

--- a/src/templates/singleBusinessPage.js
+++ b/src/templates/singleBusinessPage.js
@@ -27,9 +27,14 @@ import { useBusinessDetails } from '../hooks/useBusinessDetails';
 
 const SingleBusinessPage = ({ location, params }) => {
   const theme = useTheme();
-  const { id: businessSlug } = params;
-  const splitSlug = businessSlug && businessSlug.split('-');
-  const businessId = splitSlug.length > 0 && splitSlug[splitSlug.length - 1];
+
+  let businessId = '';
+
+  if (typeof window !== `undefined`) {
+    const { id: businessSlug } = params;
+    const splitSlug = businessSlug && businessSlug.split('-');
+    businessId = splitSlug.length > 0 && splitSlug[splitSlug.length - 1];
+  }
 
   const { data: apiResponse, isError } = useBusinessDetails(businessId);
 

--- a/src/templates/singleBusinessPage.js
+++ b/src/templates/singleBusinessPage.js
@@ -99,8 +99,37 @@ const SingleBusinessPage = ({ location, params }) => {
   if (takesCredit) paymentTypes.push('credit');
   if (takesBitcoin) paymentTypes.push('bitcoin');
 
-  // this page returns nothing if this is not an approved business
-  if (!approved && !isError) return <Layout>{null}</Layout>;
+  // // this page returns nothing if this is not an approved business
+  if (approved === false && !isError)
+    return (
+      <Layout>
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          marginTop={['4rem', '4rem', 0, 0]}
+          marginBottom={['4rem', '4rem', 0, 0]}
+          textAlign={['center', 'center ', 'left ', 'left ']}
+          direction={['column', 'column', 'column', 'row']}
+        >
+          <Flex direction="column" maxW="335px">
+            <Text
+              as="h1"
+              fontFamily={theme.fonts['heading-slab']}
+              color={theme.colors['rbb-gray']}
+              mt={theme.spacing['med']}
+              fontWeight="900"
+              fontSize="64px"
+              lineHeight="77px"
+              textTransform="uppercase"
+              marginBottom="0.625rem"
+              textAlign="center"
+            >
+              THIS BUSINESS HAS NOT BEEN APPROVED YET !
+            </Text>
+          </Flex>
+        </Flex>
+      </Layout>
+    );
 
   if (isError) {
     return (

--- a/src/utils/business.js
+++ b/src/utils/business.js
@@ -5,11 +5,11 @@ const { toCamelCase } = require('./stringUtils');
 // business-name-with-hyphens-rec123456
 // where "rec123456" is the airtable ID for this business
 // fallback is to generate a slug of _just_ the airtable id if no name is provided
-exports.getSlugForBusiness = ({ name, businessName, airtableId }) => {
-  if (!airtableId) {
+exports.getSlugForBusiness = ({ name, businessName, dbId }) => {
+  if (!dbId) {
     return null;
   }
-  return `${slugify(businessName || name).toLowerCase()}-${airtableId}`;
+  return `${slugify(businessName || name).toLowerCase()}-${dbId}`;
 };
 
 // TODO: Replace with real fallback images for each category.


### PR DESCRIPTION


This PR implements client side routing and data fetching for individual businesses. So when a new business is added, users can directly visit its profile page without having to trigger a gatsby build.

Related to #374 
Fixes #374 

## Pages/Interfaces that will change
No design changes.  The url of the profile business page will now hold the id of the business in the database rather than the airtable id.

## Steps to test

1. Register a new business
2. Visit the profile page of the business immediately and it should be working.

### Additional notes
I set the `refetchOnWindowFocus` attribute of `React Query` to false since the business details in the profile page are being refetched on window focus and it was a bit misleading especially that we do not have a placeholder while the page is loading. This shows alot when the business does not exist, which in this case RQ will refetch several times before throwing an error. I am more than happy to discuss this further in case it has some use-case I am not aware of.