### PR TITLE
Remove in-need parameter on main businesses page

### DIFF
--- a/src/templates/businesses.js
+++ b/src/templates/businesses.js
@@ -58,7 +58,7 @@ function generateURL(filters, setPageLocation) {
 }
 
 function searchingInNeed(location) {
-  return location.pathname.match(/\/all/) ? 'false' : true;
+  return location.pathname.match(/\/all|\/businesses\/?$/) ? 'false' : true;
 }
 
 function searchCategory(category) {


### PR DESCRIPTION
Not sure this is the _best_ way to fix this, but I think it's at least a way.

This PR alters the `searchingInNeed` function within the `businesses` template to return 'false' both when the `location.pathname` is `/businesses/all` and when it is `/businesses`. The latter should only match when `/businesses` is the only URL path and should account for an optional trailing slash.

Fixes #370 

## Pages/Interfaces that will change
* Main businesses page https://www.rebuildblackbusiness.com/businesses/

### Screenshots / video of changes

<img width="1741" alt="CleanShot 2020-11-13 at 07 48 59" src="https://user-images.githubusercontent.com/1843073/99078879-bd7e1680-2584-11eb-8241-70965a5d7ff0.png">
<img width="1741" alt="CleanShot 2020-11-13 at 07 49 10" src="https://user-images.githubusercontent.com/1843073/99078884-beaf4380-2584-11eb-9ffd-c3182ff286f7.png">

## Steps to test

1. Go to rebuildblackbusiness.com and click "SEE BUSINESSES"
2. Businesses displayed should match the businesses displayed on the `/businesses/all` page
3. Pagination should display many more than 12 pages. 